### PR TITLE
SBT fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,9 @@ version := "0.1.0"
 
 scalaVersion := "2.11.7"
 
-libraryDependencies += "org.typelevel" %% "cats" % "0.4.1"
-
-libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.7.2" % "test")
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats" % "0.4.1",
+  "org.specs2" %% "specs2-core" % "3.7.2" % "test"
+)
 
 scalacOptions in Test ++= Seq("-Yrangepos")

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "uranio"
+name := "fetch"
 
 version := "0.1.0"
 


### PR DESCRIPTION
Made two small tweaks to `build.sbt` file:

* Make `libraryDependecies` key more idiomatic. We dont need to append first an element and then a sequence.
* Change name from `uranio` to `fetch`.