### PR TITLE
Abstracts over the target runtime Monad

### DIFF
--- a/shared/src/main/scala/cache.scala
+++ b/shared/src/main/scala/cache.scala
@@ -1,21 +1,17 @@
 package fetch
 
-/**
- * A marker trait for cache implementations.
- */
-trait DataSourceCache
 
 /**
  * A `Cache` trait so the users of the library can provide their own cache.
  */
-trait Cache[T <: DataSourceCache] {
-  def update[I, A](c: T, k: DataSourceIdentity, v: A): T
+trait DataSourceCache {
+  def update[I, A](k: DataSourceIdentity, v: A): DataSourceCache
 
-  def get[I](c: T, k: DataSourceIdentity): Option[Any]
+  def get[I](k: DataSourceIdentity): Option[Any]
 
-  def cacheResults[I, A, M[_]](cache: T, results: Map[I, A], ds: DataSource[I, A, M]): T = {
-    results.foldLeft(cache)({
-      case (acc, (i, a)) => update(acc, ds.identity(i), a)
+  def cacheResults[I, A](results: Map[I, A], ds: DataSource[I, A]): DataSourceCache = {
+    results.foldLeft(this)({
+      case (acc, (i, a)) => acc.update(ds.identity(i), a)
     })
   }
 }

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -1,12 +1,14 @@
 package fetch
 
+import cats.Eval
+
 /**
  * A `DataSource` is the recipe for fetching a certain identity `I`, which yields
  * results of type `A` with the concurrency and error handling specified by the Monad
  * `M`.
  */
-trait DataSource[I, A, M[_]] {
+trait DataSource[I, A] {
   def name: DataSourceName = this.toString
   def identity(i: I): DataSourceIdentity = (name, i)
-  def fetch(ids: List[I]): M[Map[I, A]]
+  def fetch(ids: List[I]): Eval[Map[I, A]]
 }

--- a/shared/src/main/scala/env.scala
+++ b/shared/src/main/scala/env.scala
@@ -6,8 +6,8 @@ import scala.collection.immutable._
  * An environment that is passed along during the fetch rounds. It holds the
  * cache and the list of rounds that have been executed.
  */
-trait Env[C <: DataSourceCache] {
-  def cache: C
+trait Env {
+  def cache: DataSourceCache
   def rounds: Seq[Round]
 
   def cached: Seq[Round] =
@@ -17,10 +17,10 @@ trait Env[C <: DataSourceCache] {
     rounds.filterNot(_.cached)
 
   def next(
-    newCache: C,
+    newCache: DataSourceCache,
     newRound: Round,
     newIds: List[Any]
-  ): Env[C]
+  ): Env
 }
 
 /**
@@ -50,16 +50,16 @@ final case class ConcurrentRound(ids: Map[String, List[Any]]) extends RoundKind
 /**
  * A concrete implementation of `Env` used in the default Fetch interpreter.
  */
-case class FetchEnv[C <: DataSourceCache](
-  cache: C,
+case class FetchEnv(
+  cache: DataSourceCache,
   ids: List[Any] = Nil,
   rounds: Queue[Round] = Queue.empty
-) extends Env[C] {
+) extends Env {
   def next(
-    newCache: C,
+    newCache: DataSourceCache,
     newRound: Round,
     newIds: List[Any]
-  ): FetchEnv[C] =
+  ): FetchEnv =
     copy(cache = newCache, rounds = rounds :+ newRound, ids = newIds)
 }
 

--- a/shared/src/main/scala/implicits.scala
+++ b/shared/src/main/scala/implicits.scala
@@ -6,7 +6,13 @@ import cats.{MonadError}
 /**
  * A cache that stores its elements in memory.
  */
-case class InMemoryCache(state: Map[Any, Any]) extends DataSourceCache
+case class InMemoryCache(state: Map[Any, Any]) extends DataSourceCache {
+  override def get[I](k: DataSourceIdentity): Option[Any] =
+    state.get(k)
+
+  override def update[I, A](k: DataSourceIdentity, v: A): InMemoryCache =
+    InMemoryCache(state.updated(k, v))
+}
 
 object InMemoryCache {
   def empty: InMemoryCache = InMemoryCache(Map.empty[Any, Any])
@@ -51,14 +57,6 @@ object implicits {
       } catch {
         case e: Throwable => f(e)
       }
-  }
-
-  implicit object InMemoryCacheImpl extends Cache[InMemoryCache] {
-    override def get[I](c: InMemoryCache, k: DataSourceIdentity): Option[Any] =
-      c.state.get(k)
-
-    override def update[I, A](c: InMemoryCache, k: DataSourceIdentity, v: A): InMemoryCache =
-      InMemoryCache(c.state.updated(k, v))
   }
 
 }

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -81,7 +81,7 @@ trait FetchInterpreters {
               val startRound = System.nanoTime()
               val cache = env.cache
               cache.get(ds.identity(id)).fold[M[(FetchEnv, A)]](
-                MM.flatMap(ds.fetch(List(id)).asInstanceOf[M[Map[I, A]]])((res: Map[I, A]) => {
+                MM.flatMap(MM.pureEval(ds.fetch(List(id))).asInstanceOf[M[Map[I, A]]])((res: Map[I, A]) => {
                   val endRound = System.nanoTime()
                   res.get(id.asInstanceOf[I]).fold[M[(FetchEnv, A)]](
                     MM.raiseError(
@@ -130,7 +130,7 @@ trait FetchInterpreters {
                   ), ids.flatMap(id => cache.get(ds.identity(id))))
                 )
               else {
-                MM.flatMap(ds.fetch(newIds).asInstanceOf[M[Map[I, A]]])((res: Map[I, A]) => {
+                MM.flatMap(MM.pureEval(ds.fetch(newIds)).asInstanceOf[M[Map[I, A]]])((res: Map[I, A]) => {
                   val endRound = System.nanoTime()
                   ids.map(i => res.get(i.asInstanceOf[I])).sequence.fold[M[(FetchEnv, A)]](
                     MM.raiseError(

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -13,22 +13,21 @@ import cats.syntax.traverse._
 /**
  * An exception thrown from the interpreter when failing to perform a data fetch.
  */
-case class FetchFailure[C <: DataSourceCache](env: Env[C])(implicit CC: Cache[C]) extends Throwable
+case class FetchFailure[C <: DataSourceCache](env: Env) extends Throwable
 
 trait FetchInterpreters {
 
-  def interpreter[C <: DataSourceCache, I, E <: Env[C], M[_]](
+  def interpreter[I, M[_]](
     implicit
-    MM: MonadError[M, Throwable],
-    CC: Cache[C]
-  ): FetchOp ~> FetchInterpreter[M, C]#f = {
-    def dedupeIds[I, A, M[_]](ids: List[I], ds: DataSource[I, A, M], cache: C) = {
-      ids.distinct.filterNot(i => CC.get(cache, ds.identity(i)).isDefined)
+    MM: MonadError[M, Throwable]
+  ): FetchOp ~> FetchInterpreter[M]#f = {
+    def dedupeIds[I, A, M[_]](ids: List[I], ds: DataSource[I, A], cache: DataSourceCache) = {
+      ids.distinct.filterNot(i => cache.get(ds.identity(i)).isDefined)
     }
 
-    new (FetchOp ~> FetchInterpreter[M, C]#f) {
-      def apply[A](fa: FetchOp[A]): FetchInterpreter[M, C]#f[A] = {
-        StateT[M, FetchEnv[C], A] { env: FetchEnv[C] =>
+    new (FetchOp ~> FetchInterpreter[M]#f) {
+      def apply[A](fa: FetchOp[A]): FetchInterpreter[M]#f[A] = {
+        StateT[M, FetchEnv, A] { env: FetchEnv =>
           fa match {
             case FetchError(e) => MM.raiseError(e)
             case Cached(a) => MM.pure((env, a))
@@ -41,7 +40,7 @@ trait FetchInterpreters {
               val sourcesAndIds = (sources zip ids).map({
                 case (ds, ids) => (
                   ds,
-                  dedupeIds[I, A, M](ids.asInstanceOf[List[I]], ds.asInstanceOf[DataSource[I, A, M]], cache)
+                  dedupeIds[I, A, M](ids.asInstanceOf[List[I]], ds.asInstanceOf[DataSource[I, A]], cache)
                 )
               }).filterNot({
                 case (_, ids) => ids.isEmpty
@@ -51,14 +50,14 @@ trait FetchInterpreters {
                 MM.pure((env, env.asInstanceOf[A]))
               else
                 MM.flatMap(sourcesAndIds.map({
-                  case (ds, as) => ds.asInstanceOf[DataSource[I, A, M]].fetch(as.asInstanceOf[List[I]])
+                  case (ds, as) => MM.pureEval(ds.asInstanceOf[DataSource[I, A]].fetch(as.asInstanceOf[List[I]]))
                 }).sequence)((results: List[Map[_, _]]) => {
                   val endRound = System.nanoTime()
                   val newCache = (sources zip results).foldLeft(cache)((accache, resultset) => {
                     val (ds, resultmap) = resultset
                     val tresults = resultmap.asInstanceOf[Map[I, A]]
-                    val tds = ds.asInstanceOf[DataSource[I, A, M]]
-                    CC.cacheResults[I, A, M](accache, tresults, tds)
+                    val tds = ds.asInstanceOf[DataSource[I, A]]
+                    accache.cacheResults[I, A](tresults, tds)
                   })
                   val newEnv = env.next(
                     newCache,
@@ -81,10 +80,10 @@ trait FetchInterpreters {
             case FetchOne(id, ds) => {
               val startRound = System.nanoTime()
               val cache = env.cache
-              CC.get(cache, ds.identity(id)).fold[M[(FetchEnv[C], A)]](
+              cache.get(ds.identity(id)).fold[M[(FetchEnv, A)]](
                 MM.flatMap(ds.fetch(List(id)).asInstanceOf[M[Map[I, A]]])((res: Map[I, A]) => {
                   val endRound = System.nanoTime()
-                  res.get(id.asInstanceOf[I]).fold[M[(FetchEnv[C], A)]](
+                  res.get(id.asInstanceOf[I]).fold[M[(FetchEnv, A)]](
                     MM.raiseError(
                       FetchFailure(
                         env.next(
@@ -96,7 +95,7 @@ trait FetchInterpreters {
                     )
                   )(result => {
                       val endRound = System.nanoTime()
-                      val newCache = CC.update(cache, ds.identity(id), result)
+                      val newCache = cache.update(ds.identity(id), result)
                       MM.pure(
                         (env.next(
                           newCache,
@@ -128,12 +127,12 @@ trait FetchInterpreters {
                     cache,
                     Round(cache, ds.name, ManyRound(ids), startRound, System.nanoTime(), true),
                     newIds
-                  ), ids.flatMap(id => CC.get(cache, ds.identity(id))))
+                  ), ids.flatMap(id => cache.get(ds.identity(id))))
                 )
               else {
                 MM.flatMap(ds.fetch(newIds).asInstanceOf[M[Map[I, A]]])((res: Map[I, A]) => {
                   val endRound = System.nanoTime()
-                  ids.map(i => res.get(i.asInstanceOf[I])).sequence.fold[M[(FetchEnv[C], A)]](
+                  ids.map(i => res.get(i.asInstanceOf[I])).sequence.fold[M[(FetchEnv, A)]](
                     MM.raiseError(
                       FetchFailure(
                         env.next(
@@ -145,7 +144,7 @@ trait FetchInterpreters {
                     )
                   )(results => {
                       val endRound = System.nanoTime()
-                      val newCache = CC.cacheResults[I, A, M](cache, res, ds.asInstanceOf[DataSource[I, A, M]])
+                      val newCache = cache.cacheResults[I, A](res, ds.asInstanceOf[DataSource[I, A]])
                       val someCached = oldIds.size == newIds.size
                       MM.pure(
                         (env.next(

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -507,97 +507,97 @@ class FetchTests extends FreeSpec with Matchers {
   }
 }
 
-// class FetchFutureTests extends AsyncFreeSpec with Matchers{
-//   import scala.concurrent._
-//   import scala.concurrent.ExecutionContext.global
+class FetchFutureTests extends AsyncFreeSpec with Matchers{
+  import scala.concurrent._
+  import scala.concurrent.ExecutionContext.global
 
-//   import cats.std.future._
+  import cats.std.future._
 
-//   implicit def executionContext = global
-//   override def newInstance = new FetchFutureTests
+  implicit def executionContext = global
+  override def newInstance = new FetchFutureTests
 
-//   case class ArticleId(id: Int)
-//   case class Article(id: Int, content: String) {
-//     def author: Int = id + 1
-//   }
+  case class ArticleId(id: Int)
+  case class Article(id: Int, content: String) {
+    def author: Int = id + 1
+  }
 
-//   implicit object ArticleFuture extends DataSource[ArticleId, Article, Future] {
-//     override def name = "ArticleFuture"
-//     override def fetch(ids: List[ArticleId]): Future[Map[ArticleId, Article]] = {
-//       Future({
-//         ids.map(tid => (tid, Article(tid.id, "An article with id " + tid.id))).toMap
-//       })
-//     }
-//   }
+  implicit object ArticleFuture extends DataSource[ArticleId, Article] {
+    override def name = "ArticleFuture"
+    override def fetch(ids: List[ArticleId]): Eval[Map[ArticleId, Article]] = {
+      Eval.later({
+        ids.map(tid => (tid, Article(tid.id, "An article with id " + tid.id))).toMap
+      })
+    }
+  }
 
-//   def article(id: Int): Fetch[Article] = Fetch(ArticleId(id))
+  def article(id: Int): Fetch[Article] = Fetch(ArticleId(id))
 
-//   case class AuthorId(id: Int)
-//   case class Author(id: Int, name: String)
+  case class AuthorId(id: Int)
+  case class Author(id: Int, name: String)
 
-//   implicit object AuthorFuture extends DataSource[AuthorId, Author, Future] {
-//     override def name = "AuthorFuture"
-//     override def fetch(ids: List[AuthorId]): Future[Map[AuthorId, Author]] = {
-//       Future({
-//         ids.map(tid => (tid, Author(tid.id, "@egg" + tid.id))).toMap
-//       })
-//     }
-//   }
+  implicit object AuthorFuture extends DataSource[AuthorId, Author] {
+    override def name = "AuthorFuture"
+    override def fetch(ids: List[AuthorId]): Eval[Map[AuthorId, Author]] = {
+      Eval.later({
+        ids.map(tid => (tid, Author(tid.id, "@egg" + tid.id))).toMap
+      })
+    }
+  }
 
-//   def author(a: Article): Fetch[Author] = Fetch(AuthorId(a.author))
+  def author(a: Article): Fetch[Author] = Fetch(AuthorId(a.author))
 
-//   "We can interpret a fetch into a future" in {
-//     val fetch: Fetch[Article] = article(1)
+  "We can interpret a fetch into a future" in {
+    val fetch: Fetch[Article] = article(1)
 
-//     val fut: Future[Article] = Fetch.run(fetch)
+    val fut: Future[Article] = Fetch.run(fetch)
 
-//     fut.map(_ shouldEqual Article(1, "An article with id 1"))
-//   }
+    fut.map(_ shouldEqual Article(1, "An article with id 1"))
+  }
 
-//   "We can combine several data sources and interpret a fetch into a future" in {
-//     val fetch: Fetch[(Article, Author)] = for {
-//       art <- article(1)
-//       author <- author(art)
-//     } yield (art, author)
+  "We can combine several data sources and interpret a fetch into a future" in {
+    val fetch: Fetch[(Article, Author)] = for {
+      art <- article(1)
+      author <- author(art)
+    } yield (art, author)
 
-//     val fut: Future[(Article, Author)] = Fetch.run(fetch)
+    val fut: Future[(Article, Author)] = Fetch.run(fetch)
 
-//     fut.map(_ shouldEqual (Article(1, "An article with id 1"), Author(2, "@egg2")))
-//   }
+    fut.map(_ shouldEqual (Article(1, "An article with id 1"), Author(2, "@egg2")))
+  }
 
-//   "We can use combinators in a for comprehension and interpret a fetch into a future" in {
-//     val fetch: Fetch[List[Article]] = for {
-//       articles <- Fetch.traverse(List(1, 1, 2))(article)
-//     } yield articles
+  "We can use combinators in a for comprehension and interpret a fetch into a future" in {
+    val fetch: Fetch[List[Article]] = for {
+      articles <- Fetch.traverse(List(1, 1, 2))(article)
+    } yield articles
 
-//     val fut: Future[List[Article]] = Fetch.run(fetch)
+    val fut: Future[List[Article]] = Fetch.run(fetch)
 
-//     fut.map(_ shouldEqual List(
-//       Article(1, "An article with id 1"),
-//       Article(1, "An article with id 1"),
-//       Article(2, "An article with id 2")
-//     ))
-//   }
+    fut.map(_ shouldEqual List(
+      Article(1, "An article with id 1"),
+      Article(1, "An article with id 1"),
+      Article(2, "An article with id 2")
+    ))
+  }
 
-//   "We can use combinators and multiple sources in a for comprehension and interpret a fetch into a future" in {
-//     val fetch = for {
-//       articles <- Fetch.traverse(List(1, 1, 2))(article)
-//       authors <- Fetch.traverse(articles)(author)
-//     } yield (articles, authors)
+  "We can use combinators and multiple sources in a for comprehension and interpret a fetch into a future" in {
+    val fetch = for {
+      articles <- Fetch.traverse(List(1, 1, 2))(article)
+      authors <- Fetch.traverse(articles)(author)
+    } yield (articles, authors)
 
-//     val fut: Future[(List[Article], List[Author])] = Fetch.run(fetch, InMemoryCache.empty)
+    val fut: Future[(List[Article], List[Author])] = Fetch.run(fetch, InMemoryCache.empty)
 
-//     fut.map(_ shouldEqual (
-//       List(
-//         Article(1, "An article with id 1"),
-//         Article(1, "An article with id 1"),
-//         Article(2, "An article with id 2")
-//       ),
-//       List(
-//         Author(2, "@egg2"),
-//         Author(2, "@egg2"),
-//         Author(3, "@egg3")
-//       )
-//     ))
-//   }
-// }
+    fut.map(_ shouldEqual (
+      List(
+        Article(1, "An article with id 1"),
+        Article(1, "An article with id 1"),
+        Article(2, "An article with id 2")
+      ),
+      List(
+        Author(2, "@egg2"),
+        Author(2, "@egg2"),
+        Author(3, "@egg3")
+      )
+    ))
+  }
+}


### PR DESCRIPTION
The following PR decouples `DataSource` impls making them agnostic of the target runtime `M[_] : MonadError[A, Throwable]` so this only needs to be known to the actual call site run semantics.
As a side effect makes `Fetch` structures re-computable to any arbitrary `M[_]` such as `Future`, `Task` etc...

@dialelo Can you please review?