### PR TITLE
Bump 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+## Version 0.3.0
+
+Date: 2016-07-25
+
+- Separate `DataSource#fetchOne` and `DataSource#fetchMany` into two methods
+- Provide `DataSource#batchingNotSupported` for implementing `fetchMany` in terms of `fetchOne`
+- Introduce `FetchMonadError[M]` typeclass for being able to run a fetch into the target monad `M`
+- Support for blocking and non-blocking data sources through the `Query` type
+- [Monix](http://monix.io) integration through the `fetch-monix` project
+
 ## Version 0.2.0
 
 Date: 2016-05-22
@@ -19,4 +29,4 @@ Date: 2016-05-20
 
 Date: 2016-05-19
 
-- First relase.
+- First relase

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Add the following dependency to your project's build file.
 For Scala 2.11.x:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %% "fetch" % "0.3.0"
 ```
 
 Or, if using Scala.js (0.6.x):
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %%% "fetch" % "0.3.0"
 ```
 
 
@@ -99,7 +99,7 @@ Let's run it and wait for the fetch to complete:
 
 ```scala
 fetchOne.runA[Id]
-// [46] One ToString 1
+// [562] One ToString 1
 // res3: cats.Id[String] = 1
 ```
 
@@ -117,7 +117,7 @@ When executing the above fetch, note how the three identities get batched and th
 
 ```scala
 fetchThree.runA[Id]
-// [46] Many ToString OneAnd(1,List(2, 3))
+// [562] Many ToString OneAnd(1,List(2, 3))
 // res5: cats.Id[(String, String, String)] = (1,2,3)
 ```
 
@@ -156,8 +156,8 @@ Note how the two independent data fetches run in parallel, minimizing the latenc
 
 ```scala
 fetchMulti.runA[Id]
-// [46] One ToString 1
-// [47] One Length one
+// [562] One ToString 1
+// [563] One Length one
 // res7: cats.Id[(String, Int)] = (1,3)
 ```
 
@@ -176,6 +176,6 @@ While running it, notice that the data source is only queried once. The next tim
 
 ```scala
 fetchTwice.runA[Id]
-// [46] One ToString 1
+// [562] One ToString 1
 // res8: cats.Id[(String, String)] = (1,1)
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val readme = (project in file("tut"))
 
 lazy val monixSettings = (
   libraryDependencies ++= Seq(
-    "io.monix" %%% "monix-eval" % "2.0-RC5"
+    "io.monix" %%% "monix-eval" % "2.0-RC8"
   )
 )
 

--- a/docs/src/jekyll/_config.yml
+++ b/docs/src/jekyll/_config.yml
@@ -6,6 +6,8 @@ style: fetch
 highlight_theme: tomorrow
 docs: true
 markdown: redcarpet
+cdn:
+  url: https://rawgit.com/47deg/microsites/cdn/
 collections:
   tut:
     output: true

--- a/docs/src/tut/docs.md
+++ b/docs/src/tut/docs.md
@@ -29,13 +29,13 @@ we read) concerns.
 To begin, add the following dependency to your SBT build file:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %% "fetch" % "0.3.0"
 ```
 
 Or, if using Scala.js:
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %%% "fetch" % "0.3.0"
 ```
 
 Now you'll have Fetch available in both Scala and Scala.js.
@@ -874,7 +874,7 @@ The [Monix](https://monix.io/) library provides an abstraction for lazy, asynchr
 For using `Task` as the target concurrency monad of a fetch, add the following dependency to your build file:
 
 ```scala
-"com.fortysevendeg" %% "fetch-monix" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %% "fetch-monix" % "0.3.0"
 ```
 
 And do some standard imports, we'll need an Scheduler for running our tasks as well as the instance of `FetchMonadError[Task]` that `fetch-monix` provides:

--- a/docs/src/tut/index.md
+++ b/docs/src/tut/index.md
@@ -13,13 +13,13 @@ Add the following dependency to your project's build file.
 For Scala 2.11.x:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %% "fetch" % "0.3.0"
 ```
 
 Or, if using Scala.js (0.6.x):
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %%% "fetch" % "0.3.0"
 ```
 
 ```tut:invisible

--- a/tut/README.md
+++ b/tut/README.md
@@ -15,13 +15,13 @@ Add the following dependency to your project's build file.
 For Scala 2.11.x:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %% "fetch" % "0.3.0"
 ```
 
 Or, if using Scala.js (0.6.x):
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0-SNAPSHOT"
+"com.fortysevendeg" %%% "fetch" % "0.3.0"
 ```
 
 ```tut:invisible

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.0-SNAPSHOT"
+version in ThisBuild := "0.3.0"


### PR DESCRIPTION
- Separate `DataSource#fetchOne` and `DataSource#fetchMany` into two methods
- Provide `DataSource#batchingNotSupported` for implementing `fetchMany` in terms of `fetchOne`
- Introduce `FetchMonadError[M]` typeclass for being able to run a fetch into the target monad `M`
- Support for blocking and non-blocking data sources through the `Query` type
- [Monix](http://monix.io) integration through the `fetch-monix` project

@raulraja plz take a look.