### PR TITLE
Improved reporting and error handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val commonSettings = Seq(
   resolvers += Resolver.sonatypeRepo("releases"),
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "cats" % "0.7.2",
-    "org.scalatest" %%% "scalatest" % "3.0.0-M7" % "test",
+    "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
     compilerPlugin(
       "org.spire-math" %% "kind-projector" % "0.7.1"
     )
@@ -129,7 +129,7 @@ lazy val readme = (project in file("tut"))
 
 lazy val monixSettings = (
   libraryDependencies ++= Seq(
-    "io.monix" %%% "monix-eval" % "2.0"
+    "io.monix" %%% "monix-eval" % "2.0.5"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val buildSettings = Seq(
 lazy val commonSettings = Seq(
   resolvers += Resolver.sonatypeRepo("releases"),
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "cats" % "0.6.0",
+    "org.typelevel" %%% "cats" % "0.7.2",
     "org.scalatest" %%% "scalatest" % "3.0.0-M7" % "test",
     compilerPlugin(
       "org.spire-math" %% "kind-projector" % "0.7.1"
@@ -129,7 +129,7 @@ lazy val readme = (project in file("tut"))
 
 lazy val monixSettings = (
   libraryDependencies ++= Seq(
-    "io.monix" %%% "monix-eval" % "2.0-RC5"
+    "io.monix" %%% "monix-eval" % "2.0"
   )
 )
 

--- a/docs/src/jekyll/_config.yml
+++ b/docs/src/jekyll/_config.yml
@@ -6,6 +6,8 @@ style: fetch
 highlight_theme: tomorrow
 docs: true
 markdown: redcarpet
+cdn:
+  url: https://rawgit.com/47deg/microsites/cdn/
 collections:
   tut:
     output: true

--- a/docs/src/tut/docs.md
+++ b/docs/src/tut/docs.md
@@ -135,7 +135,7 @@ implicit object UserSource extends DataSource[UserId, User]{
   }
   override def fetchMany(ids: NonEmptyList[UserId]): Query[Map[UserId, User]] = {
     Query.sync({
-	  latency(userDatabase.filterKeys(ids.unwrap.contains), s"Many Users $ids")
+	  latency(userDatabase.filterKeys(ids.toList.contains), s"Many Users $ids")
     })
   }
 }
@@ -347,7 +347,7 @@ implicit object PostSource extends DataSource[PostId, Post]{
   }
   override def fetchMany(ids: NonEmptyList[PostId]): Query[Map[PostId, Post]] = {
     Query.sync({
-	  latency(postDatabase.filterKeys(ids.unwrap.contains), s"Many Posts $ids")
+	  latency(postDatabase.filterKeys(ids.toList.contains), s"Many Posts $ids")
     })
   }
 }
@@ -381,7 +381,7 @@ implicit object PostTopicSource extends DataSource[Post, PostTopic]{
   }
   override def fetchMany(ids: NonEmptyList[Post]): Query[Map[Post, PostTopic]] = {
     Query.sync({
-	  val result = ids.unwrap.map(id => (id, if (id.id % 2 == 0) "monad" else "applicative")).toMap
+	  val result = ids.toList.map(id => (id, if (id.id % 2 == 0) "monad" else "applicative")).toMap
       latency(result, s"Many Post Topics $ids")
     })
   }

--- a/docs/src/tut/index.md
+++ b/docs/src/tut/index.md
@@ -63,7 +63,7 @@ We'll implement a dummy data source that can convert integers to strings. For co
 
 ```tut:silent
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 import fetch._
 
 implicit object ToStringSource extends DataSource[Int, String]{

--- a/docs/src/tut/index.md
+++ b/docs/src/tut/index.md
@@ -76,7 +76,7 @@ implicit object ToStringSource extends DataSource[Int, String]{
   override def fetchMany(ids: NonEmptyList[Int]): Query[Map[Int, String]] = {
     Query.sync({
       println(s"[${Thread.currentThread.getId}] Many ToString $ids")
-      ids.unwrap.map(i => (i, i.toString)).toMap
+      ids.toList.map(i => (i, i.toString)).toMap
     })
   }
 }
@@ -144,7 +144,7 @@ implicit object LengthSource extends DataSource[String, Int]{
   override def fetchMany(ids: NonEmptyList[String]): Query[Map[String, Int]] = {
     Query.async((ok, fail) => {
       println(s"[${Thread.currentThread.getId}] Many Length $ids")
-      ok(ids.unwrap.map(i => (i, i.size)).toMap)
+      ok(ids.toList.map(i => (i, i.size)).toMap)
     })
   }
 }

--- a/jvm/src/main/scala/unsafeImplicits.scala
+++ b/jvm/src/main/scala/unsafeImplicits.scala
@@ -54,17 +54,17 @@ object implicits {
     }
     def pure[A](x: A): Eval[A] = Eval.now(x)
 
-    def handleErrorWith[A](fa: Eval[A])(f: FetchError => Eval[A]): Eval[A] =
+    def handleErrorWith[A](fa: Eval[A])(f: FetchException => Eval[A]): Eval[A] =
       Eval.later({
         try {
           fa.value
         } catch {
-          case ex: FetchError => f(ex).value
-          case th: Throwable  => f(FetchException(th)).value
+          case ex: FetchException => f(ex).value
+          case th: Throwable      => f(UnhandledException(th)).value
         }
       })
 
-    def raiseError[A](e: FetchError): Eval[A] =
+    def raiseError[A](e: FetchException): Eval[A] =
       Eval.later({
         throw e
       })
@@ -100,15 +100,15 @@ object implicits {
         }
     }
     def pure[A](x: A): Id[A] = x
-    def handleErrorWith[A](fa: Id[A])(f: FetchError => Id[A]): Id[A] =
+    def handleErrorWith[A](fa: Id[A])(f: FetchException => Id[A]): Id[A] =
       try {
         fa
       } catch {
-        case ex: FetchError => f(ex)
+        case ex: FetchException => f(ex)
       }
-    def raiseError[A](e: FetchError): Id[A] =
+    def raiseError[A](e: FetchException): Id[A] =
       e match {
-        case FetchException(ex) => {
+        case UnhandledException(ex) => {
             e.initCause(ex)
             throw e
           }

--- a/jvm/src/main/scala/unsafeImplicits.scala
+++ b/jvm/src/main/scala/unsafeImplicits.scala
@@ -54,7 +54,8 @@ object implicits {
           }
         }
     }
-    def pure[A](x: A): Eval[A]                                    = Eval.now(x)
+    def pure[A](x: A): Eval[A] = Eval.now(x)
+
     def tailRecM[A, B](a: A)(f: A => Eval[Either[A, B]]): Eval[B] = FM.tailRecM(a)(f)
 
     def handleErrorWith[A](fa: Eval[A])(f: FetchException => Eval[A]): Eval[A] =

--- a/monix/shared/src/main/scala/monix.scala
+++ b/monix/shared/src/main/scala/monix.scala
@@ -45,10 +45,12 @@ object implicits {
     def pure[A](x: A): Task[A] =
       Task.now(x)
 
-    def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
-      fa.onErrorHandleWith(f)
+    def handleErrorWith[A](fa: Task[A])(f: FetchError => Task[A]): Task[A] =
+      fa.onErrorHandleWith({
+        case e: FetchError => f(e)
+      })
 
-    def raiseError[A](e: Throwable): Task[A] =
+    def raiseError[A](e: FetchError): Task[A] =
       Task.raiseError(e)
 
     def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] =

--- a/monix/shared/src/main/scala/monix.scala
+++ b/monix/shared/src/main/scala/monix.scala
@@ -18,7 +18,7 @@ package fetch.monixTask
 
 import fetch._
 
-import cats.{Eval, Now, Later, Always, Traverse, Applicative}
+import cats.{Eval, Now, Later, Always, Monad, RecursiveTailRecM}
 
 import monix.eval.Task
 import monix.execution.{Scheduler, Cancelable}
@@ -29,9 +29,11 @@ object implicits {
   def evalToTask[A](e: Eval[A]): Task[A] = e match {
     case Now(x)       => Task.now(x)
     case l: Later[A]  => Task.evalOnce({ l.value })
-    case a: Always[A] => Task.evalAlways({ a.value })
+    case a: Always[A] => Task.eval({ a.value })
     case other        => Task.evalOnce({ other.value })
   }
+
+  implicit val fetchTaskRecursiveTailRecM: RecursiveTailRecM[Task] = RecursiveTailRecM.create[Task]
 
   implicit val fetchTaskFetchMonadError: FetchMonadError[Task] = new FetchMonadError[Task] {
     override def map[A, B](fa: Task[A])(f: A => B): Task[B] =
@@ -40,21 +42,22 @@ object implicits {
     override def product[A, B](fa: Task[A], fb: Task[B]): Task[(A, B)] =
       Task.zip2(Task.fork(fa), Task.fork(fb))
 
-    override def pureEval[A](e: Eval[A]): Task[A] = evalToTask(e)
-
     def pure[A](x: A): Task[A] =
       Task.now(x)
 
-    def handleErrorWith[A](fa: Task[A])(f: FetchError => Task[A]): Task[A] =
+    def handleErrorWith[A](fa: Task[A])(f: FetchException => Task[A]): Task[A] =
       fa.onErrorHandleWith({
-        case e: FetchError => f(e)
+        case e: FetchException => f(e)
       })
 
-    def raiseError[A](e: FetchError): Task[A] =
+    def raiseError[A](e: FetchException): Task[A] =
       Task.raiseError(e)
 
     def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] =
       fa.flatMap(f)
+
+    def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] =
+      defaultTailRecM(a)(f)
 
     override def runQuery[A](q: Query[A]): Task[A] = q match {
       case Sync(x) => evalToTask(x)

--- a/monix/shared/src/test/scala/FetchTaskTests.scala
+++ b/monix/shared/src/test/scala/FetchTaskTests.scala
@@ -20,7 +20,7 @@ import monix.execution.Scheduler
 import org.scalatest._
 
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 
 import fetch._
 import fetch.monixTask.implicits._
@@ -28,8 +28,7 @@ import fetch.monixTask.implicits._
 import scala.concurrent.Future
 
 class FetchTaskTests extends AsyncFreeSpec with Matchers {
-  implicit def executionContext = Scheduler.Implicits.global
-  override def newInstance      = new FetchTaskTests
+  implicit override def executionContext = Scheduler.Implicits.global
 
   case class ArticleId(id: Int)
   case class Article(id: Int, content: String) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"  % "sbt-scalajs" % "0.6.8")
+addSbtPlugin("org.scala-js"  % "sbt-scalajs" % "0.6.13")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4" exclude("com.typesafe.sbt", "sbt-git"))

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -17,7 +17,7 @@
 package fetch
 
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 
@@ -51,7 +51,7 @@ trait DataSource[I, A] {
     * source doesn't support batching.
     */
   def batchingNotSupported(ids: NonEmptyList[I]): Query[Map[I, A]] = {
-    val idsList = ids.unwrap
+    val idsList = ids.toList
     idsList
       .map(fetchOne)
       .sequence

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -29,7 +29,8 @@ trait DataSource[I, A] {
 
   /** The name of the data source.
     */
-  def name: DataSourceName = this.toString
+  def name: DataSourceName      = this.getClass.getName
+  override def toString: String = name
 
   /**
     * Derive a `DataSourceIdentity` from an identity, suitable for storing the result

--- a/shared/src/main/scala/env.scala
+++ b/shared/src/main/scala/env.scala
@@ -26,12 +26,6 @@ trait Env {
   def cache: DataSourceCache
   def rounds: Seq[Round]
 
-  def cached: Seq[Round] =
-    rounds.filter(_.cached)
-
-  def uncached: Seq[Round] =
-    rounds.filterNot(_.cached)
-
   def next(
       newCache: DataSourceCache,
       newRound: Round,

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -70,10 +70,11 @@ sealed trait FetchQuery[I, A] extends FetchRequest {
   def identities: NonEmptyList[I]
 }
 
-trait FetchError extends Throwable with Product with Serializable
-case class NotFound(env: Env, request: FetchOne[_, _])                          extends FetchError
-case class MissingIdentities(env: Env, missing: Map[DataSourceName, List[Any]]) extends FetchError
-case class FetchException(err: Throwable)                                       extends FetchError
+trait FetchException extends Throwable with Product with Serializable
+case class NotFound(env: Env, request: FetchOne[_, _]) extends FetchException
+case class MissingIdentities(env: Env, missing: Map[DataSourceName, List[Any]])
+    extends FetchException
+case class UnhandledException(err: Throwable) extends FetchException
 
 /**
   * Primitive operations in the Fetch Free monad.
@@ -122,7 +123,7 @@ object `package` {
 
   type Fetch[A] = Free[FetchOp, A]
 
-  trait FetchMonadError[M[_]] extends MonadError[M, FetchError] {
+  trait FetchMonadError[M[_]] extends MonadError[M, FetchException] {
     def runQuery[A](q: Query[A]): M[A]
   }
 

--- a/shared/src/main/scala/implicits.scala
+++ b/shared/src/main/scala/implicits.scala
@@ -44,9 +44,9 @@ object implicits extends FutureInstances {
           })
     }
     def pure[A](x: A): Future[A] = Future.successful(x)
-    def handleErrorWith[A](fa: Future[A])(f: Throwable => Future[A]): Future[A] =
-      fa.recoverWith({ case t => f(t) })
-    def raiseError[A](e: Throwable): Future[A]                     = Future.failed(e)
+    def handleErrorWith[A](fa: Future[A])(f: FetchError => Future[A]): Future[A] =
+      fa.recoverWith({ case t: FetchError => f(t) })
+    def raiseError[A](e: FetchError): Future[A]                    = Future.failed(e)
     def flatMap[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)
   }
 }

--- a/shared/src/main/scala/implicits.scala
+++ b/shared/src/main/scala/implicits.scala
@@ -44,9 +44,9 @@ object implicits extends FutureInstances {
           })
     }
     def pure[A](x: A): Future[A] = Future.successful(x)
-    def handleErrorWith[A](fa: Future[A])(f: FetchError => Future[A]): Future[A] =
-      fa.recoverWith({ case t: FetchError => f(t) })
-    def raiseError[A](e: FetchError): Future[A]                    = Future.failed(e)
+    def handleErrorWith[A](fa: Future[A])(f: FetchException => Future[A]): Future[A] =
+      fa.recoverWith({ case t: FetchException => f(t) })
+    def raiseError[A](e: FetchException): Future[A]                = Future.failed(e)
     def flatMap[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)
   }
 }

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -124,7 +124,6 @@ trait FetchInterpreters {
                 if (queries.isEmpty)
                   M.pure((env, cache.asInstanceOf[A]))
                 else {
-                  // fixme: duplicated identities allowed!
                   val sentQueries = M.sequence(queries.map({
                     case FetchOne(a, ds) => {
                         val ident = a.asInstanceOf[I]

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -19,182 +19,186 @@ package fetch
 import scala.collection.immutable._
 
 import cats.{MonadError, ~>}
-import cats.data.{StateT, NonEmptyList}
+import cats.data.{OptionT, NonEmptyList, StateT, Validated, XorT}
 import cats.instances.option._
 import cats.instances.list._
+import cats.instances.map._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.functorFilter._
+import cats.syntax.option._
 import cats.syntax.traverse._
+import cats.syntax.validated._
 
 trait FetchInterpreters {
   def pendingQueries(
-      queries: List[FetchQuery[_, _]], cache: DataSourceCache): List[FetchQuery[Any, Any]] = {
-
-    queries
-      .filterNot(_.fullfilledBy(cache))
-      .map(req => {
-        (req.dataSource, req.missingIdentities(cache))
-      })
-      .collect({
-        case (ds, ids) if ids.size == 1 =>
-          FetchOne[Any, Any](ids.head, ds.asInstanceOf[DataSource[Any, Any]])
-        case (ds, ids) if ids.size > 1 =>
-          FetchMany[Any, Any](
-              NonEmptyList(ids(0), ids.tail), ds.asInstanceOf[DataSource[Any, Any]])
-      })
-  }
+      queries: List[FetchQuery[_, _]],
+      cache: DataSourceCache
+  ): List[FetchQuery[Any, Any]] =
+    queries.mapFilter { query =>
+      val dsAny = query.dataSource.castDS[Any, Any]
+      NonEmptyList.fromList(query.missingIdentities(cache)).map {
+        case NonEmptyList(id, Nil) => FetchOne(id, dsAny)
+        case ids                   => FetchMany(ids.widen[Any], dsAny)
+      }
+    }
 
   def interpreter[I, M[_]](
       implicit M: FetchMonadError[M]
   ): FetchOp ~> FetchInterpreter[M]#f = {
     new (FetchOp ~> FetchInterpreter[M]#f) {
-      def apply[A](fa: FetchOp[A]): FetchInterpreter[M]#f[A] = {
+      def apply[A](fa: FetchOp[A]): FetchInterpreter[M]#f[A] =
         StateT[M, FetchEnv, A] { env: FetchEnv =>
           fa match {
-            case Thrown(e)  => M.raiseError(UnhandledException(e))
-            case Fetched(a) => M.pure((env, a))
-            case one @ FetchOne(id, ds) => {
-                val startRound = System.nanoTime()
-                val cache      = env.cache
-
-                cache
-                  .get[A](ds.identity(id))
-                  .fold[M[(FetchEnv, A)]](
-                      M.flatMap(M.runQuery(ds.fetchOne(id)))((res: Option[A]) => {
-                        val endRound = System.nanoTime()
-                        res.fold[M[(FetchEnv, A)]](
-                            M.raiseError(
-                                NotFound(env, one)
-                            )
-                        )(result => {
-                          val endRound = System.nanoTime()
-                          val newCache = cache.update(ds.identity(id), result)
-                          val round    = Round(cache, one, result, startRound, endRound)
-                          M.pure(env.evolve(round, newCache) -> result)
-                        })
-                      })
-                  )(cached => {
-                    val endRound = System.nanoTime()
-                    M.pure(env -> cached)
-                  })
-              }
-            case many @ FetchMany(ids, ds) => {
-                val startRound = System.nanoTime()
-                val cache      = env.cache
-                val newIds     = many.missingIdentities(cache)
-                val result     = ids.toList.flatMap(id => cache.get(ds.identity(id)))
-
-                if (newIds.isEmpty)
-                  M.pure(env -> result)
-                else {
-                  M.flatMap(M.runQuery(ds
-                            .asInstanceOf[DataSource[I, A]]
-                            .fetchMany(NonEmptyList(newIds(0).asInstanceOf[I],
-                                                    newIds.tail.asInstanceOf[List[I]]))))(
-                      (res: Map[I, A]) => {
-                    val endRound = System.nanoTime()
-
-                    ids.toList
-                      .map(i => res.get(i.asInstanceOf[I]))
-                      .sequence
-                      .fold[M[(FetchEnv, A)]]({
-                        val missingIdentities = ids.toList
-                          .map(i => i.asInstanceOf[I] -> res.get(i.asInstanceOf[I]))
-                          .collect({
-                            case (i, None) => i
-                          })
-                        M.raiseError(
-                            MissingIdentities(env, Map(ds.name -> missingIdentities))
-                        )
-                      })(results => {
-                        val endRound = System.nanoTime()
-                        val newCache =
-                          cache.cacheResults[I, A](res, ds.asInstanceOf[DataSource[I, A]])
-                        val round = Round(cache, many, results, startRound, endRound)
-                        M.pure(env.evolve(round, newCache) -> results.asInstanceOf[A])
-                      })
-                  })
-                }
-              }
-
-            case conc @ Concurrent(concurrentQueries) => {
-                val startRound = System.nanoTime()
-                val cache      = env.cache
-
-                val queries: List[FetchQuery[Any, Any]] = pendingQueries(concurrentQueries, cache)
-
-                if (queries.isEmpty)
-                  M.pure((env, cache.asInstanceOf[A]))
-                else {
-                  val sentQueries = M.sequence(queries.map({
-                    case FetchOne(a, ds) => {
-                        val ident = a.asInstanceOf[I]
-                        val task  = M.runQuery(ds.asInstanceOf[DataSource[I, A]].fetchOne(ident))
-                        M.map(task)((r: Option[A]) =>
-                              r.fold(Map.empty[I, A])((result: A) => Map(ident -> result)))
-                      }
-                    case FetchMany(as, ds) =>
-                      M.runQuery(ds
-                            .asInstanceOf[DataSource[I, A]]
-                            .fetchMany(as.asInstanceOf[NonEmptyList[I]]))
-                  }))
-
-                  M.flatMap(sentQueries)((results: List[Map[_, _]]) => {
-                    val endRound = System.nanoTime()
-                    val newCache = (queries zip results).foldLeft(cache)((accache, resultset) => {
-                      val (req, resultmap) = resultset
-                      val ds               = req.dataSource
-                      val tresults         = resultmap.asInstanceOf[Map[I, A]]
-                      val tds              = ds.asInstanceOf[DataSource[I, A]]
-                      accache.cacheResults[I, A](tresults, tds)
-                    })
-
-                    val allFullfilled = (queries zip results).forall({
-                      case (FetchOne(_, _), results)   => results.size == 1
-                      case (FetchMany(as, _), results) => as.toList.size == results.size
-                      case _                           => false
-                    })
-
-                    if (allFullfilled) {
-                      val round = Round(
-                          cache,
-                          Concurrent(queries),
-                          results,
-                          startRound,
-                          endRound
-                      )
-                      val newEnv = env.evolve(round, newCache)
-                      // since user-provided caches may discard elements, we use an in-memory
-                      // cache to gather these intermediate results that will be used for
-                      // concurrent optimizations.
-                      val cachedResults =
-                        (queries zip results).foldLeft(InMemoryCache.empty)((cach, resultSet) => {
-                          val (req, resultmap) = resultSet
-                          val ds               = req.dataSource
-                          val tresults         = resultmap.asInstanceOf[Map[I, A]]
-                          val tds              = ds.asInstanceOf[DataSource[I, A]]
-                          cach.cacheResults[I, A](tresults, tds).asInstanceOf[InMemoryCache]
-                        })
-
-                      M.pure((newEnv, cachedResults.asInstanceOf[A]))
-                    } else {
-                      val missingIdentities: Map[DataSourceName, List[Any]] = (queries zip results)
-                        .collect({
-                          case (FetchOne(id, ds), results) if results.size != 1 =>
-                            ds.name -> List(id)
-                          case (FetchMany(as, ds), results) if results.size != as.toList.size =>
-                            ds.name -> as.toList.collect({
-                              case i if !results.asInstanceOf[Map[Any, Any]].get(i).isDefined => i
-                            })
-                        })
-                        .toMap
-                      M.raiseError(
-                          MissingIdentities(env, missingIdentities)
-                      )
-                    }
-                  })
-                }
-              }
+            case Thrown(e)              => M.raiseError(UnhandledException(e))
+            case Fetched(a)             => M.pure((env, a))
+            case one @ FetchOne(_, _)   => processOne(one, env)
+            case many @ FetchMany(_, _) => processMany(many, env)
+            case conc @ Concurrent(_)   => processConcurrent(conc, env)
           }
         }
+    }
+  }
+
+  private[this] def processOne[M[_], A](
+      one: FetchOne[Any, A],
+      env: FetchEnv
+  )(
+      implicit M: FetchMonadError[M]
+  ): M[(FetchEnv, A)] = {
+    val FetchOne(id, ds) = one
+    val startRound       = System.nanoTime()
+    env.cache
+      .get[A](ds.identity(id))
+      .fold[M[(FetchEnv, A)]](
+          M.runQuery(ds.fetchOne(id)).flatMap { (res: Option[A]) =>
+            val endRound = System.nanoTime()
+            res.fold[M[(FetchEnv, A)]] {
+              // could not get result from datasource
+              M.raiseError(NotFound(env, one))
+            } { result =>
+              // found result (and update cache)
+              val newCache = env.cache.update(ds.identity(id), result)
+              val round    = Round(env.cache, one, result, startRound, endRound)
+              M.pure(env.evolve(round, newCache) -> result)
+            }
+          }
+      ) { cached =>
+        // get result from cache
+        M.pure(env -> cached)
+      }
+  }
+
+  private[this] def processMany[M[_], A](
+      many: FetchMany[Any, Any],
+      env: FetchEnv
+  )(
+      implicit M: FetchMonadError[M],
+      ev: List[Any] =:= A
+  ): M[(FetchEnv, A)] = {
+    val ids        = many.as
+    val ds         = many.ds //.castDS[Any, Any]
+    val startRound = System.nanoTime()
+    val cache      = env.cache
+    val newIds     = many.missingIdentities(cache)
+
+    (for {
+      newIdsNel <- XorT.fromXor[M] {
+                    NonEmptyList.fromList(newIds).toRightXor {
+                      // no missing ids, get all from cache
+                      val cachedResults = ids.toList.mapFilter(id => cache.get(ds.identity(id)))
+                      env -> cachedResults
+                    }
+                  }
+      resMap <- XorT.right(M.runQuery(ds.fetchMany(newIdsNel)))
+      results <- ids.toList
+                  .traverseU(id => resMap.get(id).toValidNel(id))
+                  .fold[XorT[M, (FetchEnv, List[Any]), List[Any]]]({ missingIds =>
+                    // not all identities could be found
+                    val map = Map(ds.name -> missingIds.toList)
+                    XorT.left(M.raiseError(MissingIdentities(env, map)))
+                  }, XorT.pure)
+    } yield {
+      // found all results (and update cache)
+      val endRound = System.nanoTime()
+      val newCache = cache.cacheResults(resMap, ds)
+      val round    = Round(cache, many, results, startRound, endRound)
+      env.evolve(round, newCache) -> results
+    }).merge.map { case (env, l) => (env, ev(l)) } // A =:= List[Any]
+  }
+
+  private[this] def processConcurrent[M[_]](
+      concurrent: Concurrent,
+      env: FetchEnv
+  )(
+      implicit M: FetchMonadError[M]
+  ): M[(FetchEnv, DataSourceCache)] = {
+    def runFetchQueryAsMap[I, A](op: FetchQuery[I, A]): M[Map[I, A]] =
+      op match {
+        case FetchOne(a, ds) =>
+          OptionT(M.runQuery(ds.fetchOne(a))).map(r => Map(a -> r)).getOrElse(Map.empty)
+        case FetchMany(as, ds) => M.runQuery(ds.fetchMany(as))
+      }
+
+    type MissingIdentitiesMap = Map[DataSourceName, List[Any]]
+
+    // Give for a list of queries and result(maps) all the missing identities
+    def missingIdentitiesOrAllFulfilled(
+        queriesAndResults: List[(FetchQuery[Any, Any], Map[Any, Any])]
+    ): Validated[MissingIdentitiesMap, Unit] =
+      queriesAndResults.traverseU_ {
+        case (FetchOne(id, ds), resultMap) =>
+          Either.cond(resultMap.size == 1, (), Map(ds.name -> List(id))).toValidated
+        case (FetchMany(as, ds), resultMap) =>
+          Either
+            .cond(as.toList.size == resultMap.size,
+                  (),
+                  Map(ds.name -> as.toList.filter(id => resultMap.get(id).isEmpty)))
+            .toValidated
+        case _ =>
+          Map.empty[DataSourceName, List[Any]].invalid
+      }
+
+    val startRound = System.nanoTime()
+    val cache      = env.cache
+
+    val queries: List[FetchQuery[Any, Any]] = pendingQueries(concurrent.as, cache)
+
+    if (queries.isEmpty)
+      // there are no pending queries
+      M.pure((env, cache))
+    else {
+      val sentRequests = queries.traverse(r => runFetchQueryAsMap(r))
+
+      sentRequests.flatMap { results =>
+        val endRound          = System.nanoTime()
+        val queriesAndResults = queries zip results
+
+        val missingOrFulfilled = missingIdentitiesOrAllFulfilled(queriesAndResults)
+
+        missingOrFulfilled.fold({ missingIds =>
+          // not all identiies were found
+          M.raiseError(MissingIdentities(env, missingIds))
+        }, { _ =>
+          // results found for all identities
+          val round = Round(cache, Concurrent(queries), results, startRound, endRound)
+
+          // since user-provided caches may discard elements, we use an in-memory
+          // cache to gather these intermediate results that will be used for
+          // concurrent optimizations.
+          val (newCache, cachedResults) =
+            queriesAndResults.foldLeft((cache, InMemoryCache.empty)) {
+              case ((userCache, internCache), (req, resultMap)) =>
+                val anyMap = resultMap.asInstanceOf[Map[Any, Any]]
+                val anyDS  = req.dataSource.castDS[Any, Any]
+                (userCache.cacheResults(anyMap, anyDS),
+                 internCache.cacheResults(anyMap, anyDS).asInstanceOf[InMemoryCache])
+            }
+
+          M.pure((env.evolve(round, newCache), cachedResults))
+        })
       }
     }
   }

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -49,7 +49,7 @@ trait FetchInterpreters {
       def apply[A](fa: FetchOp[A]): FetchInterpreter[M]#f[A] = {
         StateT[M, FetchEnv, A] { env: FetchEnv =>
           fa match {
-            case Thrown(e)  => M.raiseError(FetchException(e))
+            case Thrown(e)  => M.raiseError(UnhandledException(e))
             case Fetched(a) => M.pure((env, a))
             case one @ FetchOne(id, ds) => {
                 val startRound = System.nanoTime()

--- a/shared/src/main/scala/syntax.scala
+++ b/shared/src/main/scala/syntax.scala
@@ -26,7 +26,7 @@ object syntax {
   }
 
   /** Implicit syntax to lift exception to Fetch errors */
-  implicit class FetchErrorSyntax(val a: Throwable) extends AnyVal {
+  implicit class FetchExceptionSyntax(val a: Throwable) extends AnyVal {
 
     def fetch[B]: Fetch[B] =
       Fetch.error[B](a)

--- a/shared/src/main/scala/syntax.scala
+++ b/shared/src/main/scala/syntax.scala
@@ -16,6 +16,8 @@
 
 package fetch
 
+import cats.RecursiveTailRecM
+
 object syntax {
 
   /** Implicit syntax to lift any value to the context of Fetch via pure */
@@ -38,22 +40,22 @@ object syntax {
     def join[B](fb: Fetch[B]): Fetch[(A, B)] =
       Fetch.join(fa, fb)
 
-    def runF[M[_]: FetchMonadError]: M[(FetchEnv, A)] =
+    def runF[M[_]: FetchMonadError: RecursiveTailRecM]: M[(FetchEnv, A)] =
       Fetch.runFetch[M](fa, InMemoryCache.empty)
 
-    def runE[M[_]: FetchMonadError]: M[FetchEnv] =
+    def runE[M[_]: FetchMonadError: RecursiveTailRecM]: M[FetchEnv] =
       Fetch.runEnv[M](fa, InMemoryCache.empty)
 
-    def runA[M[_]: FetchMonadError]: M[A] =
+    def runA[M[_]: FetchMonadError: RecursiveTailRecM]: M[A] =
       Fetch.run[M](fa, InMemoryCache.empty)
 
-    def runF[M[_]: FetchMonadError](cache: DataSourceCache): M[(FetchEnv, A)] =
+    def runF[M[_]: FetchMonadError: RecursiveTailRecM](cache: DataSourceCache): M[(FetchEnv, A)] =
       Fetch.runFetch[M](fa, cache)
 
-    def runE[M[_]: FetchMonadError](cache: DataSourceCache): M[FetchEnv] =
+    def runE[M[_]: FetchMonadError: RecursiveTailRecM](cache: DataSourceCache): M[FetchEnv] =
       Fetch.runEnv[M](fa, cache)
 
-    def runA[M[_]: FetchMonadError](cache: DataSourceCache): M[A] =
+    def runA[M[_]: FetchMonadError: RecursiveTailRecM](cache: DataSourceCache): M[A] =
       Fetch.run[M](fa, cache)
   }
 }

--- a/shared/src/test/scala/FetchAsyncQueryTests.scala
+++ b/shared/src/test/scala/FetchAsyncQueryTests.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 import org.scalatest._
 
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 import fetch._
 import fetch.implicits._
 

--- a/shared/src/test/scala/FetchAsyncQueryTests.scala
+++ b/shared/src/test/scala/FetchAsyncQueryTests.scala
@@ -25,8 +25,7 @@ import fetch._
 import fetch.implicits._
 
 class FetchAsyncQueryTests extends AsyncFreeSpec with Matchers {
-  implicit def executionContext = ExecutionContext.Implicits.global
-  override def newInstance      = new FetchAsyncQueryTests
+  implicit override def executionContext = ExecutionContext.Implicits.global
 
   case class ArticleId(id: Int)
   case class Article(id: Int, content: String) {

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -72,22 +72,22 @@ object TestHelper {
   def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
 
   def totalFetched(rs: Seq[Round]): Int =
-    rs.filterNot(_.cached)
-      .foldLeft(0)((acc, round) =>
-            round.kind match {
-          case OneRound(_)          => acc + 1
-          case ManyRound(ids)       => acc + ids.size
-          case ConcurrentRound(ids) => acc + ids.map(_._2.size).sum
-      })
+    rs.foldLeft(0)(
+        (acc, round) =>
+          round.kind match {
+        case OneRound(_)          => acc + 1
+        case ManyRound(ids)       => acc + ids.size
+        case ConcurrentRound(ids) => acc + ids.map(_._2.size).sum
+    })
 
   def totalBatches(rs: Seq[Round]): Int =
-    rs.filterNot(_.cached)
-      .foldLeft(0)((acc, round) =>
-            round.kind match {
-          case OneRound(_)          => acc
-          case ManyRound(ids)       => acc + 1
-          case ConcurrentRound(ids) => acc + ids.filter(_._2.size > 1).size
-      })
+    rs.foldLeft(0)(
+        (acc, round) =>
+          round.kind match {
+        case OneRound(_)          => acc
+        case ManyRound(ids)       => acc + 1
+        case ConcurrentRound(ids) => acc + ids.filter(_._2.size > 1).size
+    })
 
   def concurrent(rs: Seq[Round]): Seq[Round] =
     rs.filter(
@@ -203,14 +203,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
 
     ME.attempt(fut)
       .map(xor =>
-            xor match {
-          case Xor.Left(FetchFailure(env)) => {
-              env.rounds.headOption match {
-                case Some(Round(_, _, OneRound(Never()), _, _, _)) => assert(true)
-                case _                                             => fail("Should've thrown a fetch failure")
-              }
-            }
-          case _ => fail("Should've thrown a fetch failure")
+            xor should matchPattern {
+          case Xor.Left(FetchFailure(env, FetchOne(Never(), _))) =>
       })
   }
 
@@ -229,8 +223,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     ME.attempt(Fetch.run[Future](fetch, cache))
       .map(xor =>
             xor match {
-          case Xor.Left(FetchFailure(env)) => env.cache shouldEqual cache
-          case _                           => fail("Cache should be populated")
+          case Xor.Left(FetchFailure(env, _)) => env.cache shouldEqual cache
+          case _                              => fail("Cache should be populated")
       })
   }
 
@@ -395,8 +389,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     ME.attempt(Fetch.run[Future](fetch))
       .map(xor =>
             xor match {
-          case Xor.Left(FetchFailure(_)) => assert(true)
-          case _                         => fail("Should've thrown a fetch failure")
+          case Xor.Left(FetchFailure(_, _)) => assert(true)
+          case _                            => fail("Should've thrown a fetch failure")
       })
   }
 
@@ -407,8 +401,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     ME.attempt(fut)
       .map(xor =>
             xor match {
-          case Xor.Left(FetchFailure(_)) => assert(true)
-          case _                         => fail("Should've thrown a fetch failure")
+          case Xor.Left(FetchFailure(_, _)) => assert(true)
+          case _                            => fail("Should've thrown a fetch failure")
       })
   }
 
@@ -775,5 +769,122 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     fut.map(env => {
       totalFetched(env.rounds) shouldEqual 10
     })
+  }
+}
+
+class FetchReportingTests extends AsyncFreeSpec with Matchers {
+  import TestHelper._
+
+  val ME = implicitly[FetchMonadError[Future]]
+
+  implicit def executionContext = ExecutionContext.Implicits.global
+  override def newInstance      = new FetchReportingTests
+
+  "Plain values have no rounds of execution" in {
+    val fetch: Fetch[Int] = Fetch.pure(42)
+    Fetch.runEnv[Future](fetch).map(_.rounds.size shouldEqual 0)
+  }
+
+  "Single fetches are executed in one round" in {
+    val fetch = one(1)
+    Fetch.runEnv[Future](fetch).map(_.rounds.size shouldEqual 1)
+  }
+
+  "Single fetches are executed in one round per binding in a for comprehension" in {
+    val fetch = for {
+      o <- one(1)
+      t <- one(2)
+    } yield (o, t)
+
+    Fetch.runEnv[Future](fetch).map(_.rounds.size shouldEqual 2)
+  }
+
+  "Single fetches for different data sources are executed in multiple rounds if they are in a for comprehension" in {
+    val fetch: Fetch[(Int, List[Int])] = for {
+      o <- one(1)
+      m <- many(3)
+    } yield (o, m)
+
+    Fetch.runEnv[Future](fetch).map(_.rounds.size shouldEqual 2)
+  }
+
+  "Single fetches combined with cartesian are run in one round" in {
+    import cats.syntax.cartesian._
+
+    val fetch: Fetch[(Int, List[Int])] = (one(1) |@| many(3)).tupled
+    val fut                            = Fetch.runEnv[Future](fetch)
+
+    fut.map(_.rounds.size shouldEqual 1)
+  }
+
+  "Single fetches combined with traverse are run in one round" in {
+    import cats.std.list._
+    import cats.syntax.traverse._
+
+    val fetch: Fetch[List[Int]] = for {
+      manies <- many(3)
+      ones   <- manies.traverse(one)
+    } yield ones
+
+    val fut = Fetch.runEnv[Future](fetch)
+    fut.map(_.rounds.size shouldEqual 2)
+  }
+
+  "The product of two fetches from the same data source implies batching" in {
+    val fetch: Fetch[(Int, Int)] = Fetch.join(one(1), one(3))
+
+    Fetch
+      .runEnv[Future](fetch)
+      .map(env => {
+        env.rounds.size shouldEqual 1
+      })
+  }
+
+  "The product of concurrent fetches of the same type implies everything fetched in batches" in {
+    val fetch = Fetch.join(
+        Fetch.join(
+            for {
+              a <- one(1)
+              b <- one(2)
+              c <- one(3)
+            } yield c,
+            for {
+              a <- one(2)
+              m <- many(4)
+              c <- one(3)
+            } yield c
+        ),
+        one(3)
+    )
+
+    Fetch
+      .runEnv[Future](fetch)
+      .map(env => {
+        env.rounds.size shouldEqual 2
+      })
+  }
+
+  "Every level of sequenced concurrent of concurrent fetches is batched" in {
+    val fetch = Fetch.join(
+        Fetch.join(
+            for {
+              a <- Fetch.sequence(List(one(2), one(3), one(4)))
+              b <- Fetch.sequence(List(many(0), many(1)))
+              c <- Fetch.sequence(List(one(9), one(10), one(11)))
+            } yield c,
+            for {
+              a <- Fetch.sequence(List(one(5), one(6), one(7)))
+              b <- Fetch.sequence(List(many(2), many(3)))
+              c <- Fetch.sequence(List(one(12), one(13), one(14)))
+            } yield c
+        ),
+        Fetch.sequence(List(one(15), one(16), one(17)))
+    )
+
+    Fetch
+      .runEnv[Future](fetch)
+      .map(env => {
+        env.rounds.size shouldEqual 3
+      })
   }
 }

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -60,6 +60,7 @@ object TestHelper {
     override def fetchMany(ids: NonEmptyList[Many]): Query[Map[Many, List[Int]]] =
       Query.sync(ids.toList.map(m => (m, 0 until m.n toList)).toMap)
   }
+  def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
 
   case class Never()
   implicit object NeverSource extends DataSource[Never, Int] {
@@ -69,7 +70,6 @@ object TestHelper {
     override def fetchMany(ids: NonEmptyList[Never]): Query[Map[Never, Int]] =
       Query.sync(Map.empty[Never, Int])
   }
-  def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
 
   def requestFetches(r: FetchRequest): Int =
     r match {

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -92,7 +92,6 @@ object TestHelper {
     rs.map((round: Round) => requestBatches(round.request)).sum
 }
 
-@DoNotDiscover
 class FetchSyntaxTests extends AsyncFreeSpec with Matchers {
   import fetch.syntax._
   import TestHelper._
@@ -771,7 +770,6 @@ class FetchTests extends AsyncFreeSpec with Matchers {
   }
 }
 
-@DoNotDiscover
 class FetchReportingTests extends AsyncFreeSpec with Matchers {
   import TestHelper._
 

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -236,8 +236,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     ME.attempt(Fetch.run[Future](fetch))
       .map(xor =>
             xor match {
-          case Xor.Left(FetchException(DidNotFound())) => assert(true)
-          case _                                       => fail("Should've thrown NotFound exception")
+          case Xor.Left(UnhandledException(DidNotFound())) => assert(true)
+          case _                                           => fail("Should've thrown NotFound exception")
       })
   }
 
@@ -359,8 +359,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     ME.attempt(Fetch.run[Future](fetch))
       .map(xor =>
             xor match {
-          case Xor.Left(FetchException(DidNotFound())) => assert(true)
-          case _                                       => fail("Should've thrown NotFound exception")
+          case Xor.Left(UnhandledException(DidNotFound())) => assert(true)
+          case _                                           => fail("Should've thrown NotFound exception")
       })
   }
 
@@ -371,8 +371,8 @@ class FetchTests extends AsyncFreeSpec with Matchers {
     ME.attempt(Fetch.run[Future](fetch))
       .map(xor =>
             xor match {
-          case Xor.Left(FetchException(DidNotFound())) => assert(true)
-          case _                                       => fail("Should've thrown NotFound exception")
+          case Xor.Left(UnhandledException(DidNotFound())) => assert(true)
+          case _                                           => fail("Should've thrown NotFound exception")
       })
   }
 

--- a/tut/README.md
+++ b/tut/README.md
@@ -45,10 +45,8 @@ To tell `Fetch` how to get the data you want, you must implement the `DataSource
 
 Data Sources take two type parameters:
 
-<ol>
-<li><code>Identity</code> is a type that has enough information to fetch the data. For a users data source, this would be a user's unique ID.</li>
-<li><code>Result</code> is the type of data we want to fetch. For a users data source, this would the `User` type.</li>
-</ol>
+1. `Identity` is a type that has enough information to fetch the data. For a users data source, this would be a user's unique ID.
+2. `Result` is the type of data we want to fetch. For a users data source, this would the `User` type.
 
 ```scala
 import cats.data.NonEmptyList
@@ -63,7 +61,7 @@ We'll implement a dummy data source that can convert integers to strings. For co
 
 ```tut:silent
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 import fetch._
 
 implicit object ToStringSource extends DataSource[Int, String]{
@@ -76,7 +74,7 @@ implicit object ToStringSource extends DataSource[Int, String]{
   override def fetchMany(ids: NonEmptyList[Int]): Query[Map[Int, String]] = {
     Query.sync({
       println(s"[${Thread.currentThread.getId}] Many ToString $ids")
-      ids.unwrap.map(i => (i, i.toString)).toMap
+      ids.toList.map(i => (i, i.toString)).toMap
     })
   }
 }
@@ -141,7 +139,7 @@ implicit object LengthSource extends DataSource[String, Int]{
   override def fetchMany(ids: NonEmptyList[String]): Query[Map[String, Int]] = {
     Query.async((ok, fail) => {
       println(s"[${Thread.currentThread.getId}] Many Length $ids")
-      ok(ids.unwrap.map(i => (i, i.size)).toMap)
+      ok(ids.toList.map(i => (i, i.size)).toMap)
     })
   }
 }


### PR DESCRIPTION
@raulraja please take a look and let me know your thoughts.
- [x] Ensure that `fetchMany` is never called with duplicated identities

I've modified the interpreter for storing information about execution rounds: the request, result and timing of each request is stored in the environment. Cached requests do no longer count as rounds, so it maps better to the mental model of a fetch execution.

I also modified the error type to be a `FetchError` (which is now open to extension) and discerned between a single identity that's missing `NotFound` and potentially multiple missing identities by batching or parallel fetching `MissingIdentities`. I also wrapped exceptions thrown in data source client code in a `FetchException` type.

This will require a few changes in the Fetch exercises, I can do that after merging this PR.
