### PR TITLE
Refactor and use some more cats features

### DIFF
--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -19,182 +19,186 @@ package fetch
 import scala.collection.immutable._
 
 import cats.{MonadError, ~>}
-import cats.data.{StateT, NonEmptyList}
+import cats.data.{OptionT, NonEmptyList, StateT, Validated, XorT}
 import cats.instances.option._
 import cats.instances.list._
+import cats.instances.map._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.functorFilter._
+import cats.syntax.option._
 import cats.syntax.traverse._
+import cats.syntax.validated._
 
 trait FetchInterpreters {
   def pendingQueries(
-      queries: List[FetchQuery[_, _]], cache: DataSourceCache): List[FetchQuery[Any, Any]] = {
-
-    queries
-      .filterNot(_.fullfilledBy(cache))
-      .map(req => {
-        (req.dataSource, req.missingIdentities(cache))
-      })
-      .collect({
-        case (ds, ids) if ids.size == 1 =>
-          FetchOne[Any, Any](ids.head, ds.asInstanceOf[DataSource[Any, Any]])
-        case (ds, ids) if ids.size > 1 =>
-          FetchMany[Any, Any](
-              NonEmptyList(ids(0), ids.tail), ds.asInstanceOf[DataSource[Any, Any]])
-      })
-  }
+      queries: List[FetchQuery[_, _]],
+      cache: DataSourceCache
+  ): List[FetchQuery[Any, Any]] =
+    queries.mapFilter { query =>
+      val dsAny = query.dataSource.castDS[Any, Any]
+      NonEmptyList.fromList(query.missingIdentities(cache)).map {
+        case NonEmptyList(id, Nil) => FetchOne(id, dsAny)
+        case ids                   => FetchMany(ids.widen[Any], dsAny)
+      }
+    }
 
   def interpreter[I, M[_]](
       implicit M: FetchMonadError[M]
   ): FetchOp ~> FetchInterpreter[M]#f = {
     new (FetchOp ~> FetchInterpreter[M]#f) {
-      def apply[A](fa: FetchOp[A]): FetchInterpreter[M]#f[A] = {
+      def apply[A](fa: FetchOp[A]): FetchInterpreter[M]#f[A] =
         StateT[M, FetchEnv, A] { env: FetchEnv =>
           fa match {
-            case Thrown(e)  => M.raiseError(UnhandledException(e))
-            case Fetched(a) => M.pure((env, a))
-            case one @ FetchOne(id, ds) => {
-                val startRound = System.nanoTime()
-                val cache      = env.cache
-
-                cache
-                  .get[A](ds.identity(id))
-                  .fold[M[(FetchEnv, A)]](
-                      M.flatMap(M.runQuery(ds.fetchOne(id)))((res: Option[A]) => {
-                        val endRound = System.nanoTime()
-                        res.fold[M[(FetchEnv, A)]](
-                            M.raiseError(
-                                NotFound(env, one)
-                            )
-                        )(result => {
-                          val endRound = System.nanoTime()
-                          val newCache = cache.update(ds.identity(id), result)
-                          val round    = Round(cache, one, result, startRound, endRound)
-                          M.pure(env.evolve(round, newCache) -> result)
-                        })
-                      })
-                  )(cached => {
-                    val endRound = System.nanoTime()
-                    M.pure(env -> cached)
-                  })
-              }
-            case many @ FetchMany(ids, ds) => {
-                val startRound = System.nanoTime()
-                val cache      = env.cache
-                val newIds     = many.missingIdentities(cache)
-                val result     = ids.toList.flatMap(id => cache.get(ds.identity(id)))
-
-                if (newIds.isEmpty)
-                  M.pure(env -> result)
-                else {
-                  M.flatMap(M.runQuery(ds
-                            .asInstanceOf[DataSource[I, A]]
-                            .fetchMany(NonEmptyList(newIds(0).asInstanceOf[I],
-                                                    newIds.tail.asInstanceOf[List[I]]))))(
-                      (res: Map[I, A]) => {
-                    val endRound = System.nanoTime()
-
-                    ids.toList
-                      .map(i => res.get(i.asInstanceOf[I]))
-                      .sequence
-                      .fold[M[(FetchEnv, A)]]({
-                        val missingIdentities = ids.toList
-                          .map(i => i.asInstanceOf[I] -> res.get(i.asInstanceOf[I]))
-                          .collect({
-                            case (i, None) => i
-                          })
-                        M.raiseError(
-                            MissingIdentities(env, Map(ds.name -> missingIdentities))
-                        )
-                      })(results => {
-                        val endRound = System.nanoTime()
-                        val newCache =
-                          cache.cacheResults[I, A](res, ds.asInstanceOf[DataSource[I, A]])
-                        val round = Round(cache, many, results, startRound, endRound)
-                        M.pure(env.evolve(round, newCache) -> results.asInstanceOf[A])
-                      })
-                  })
-                }
-              }
-
-            case conc @ Concurrent(concurrentQueries) => {
-                val startRound = System.nanoTime()
-                val cache      = env.cache
-
-                val queries: List[FetchQuery[Any, Any]] = pendingQueries(concurrentQueries, cache)
-
-                if (queries.isEmpty)
-                  M.pure((env, cache.asInstanceOf[A]))
-                else {
-                  val sentQueries = M.sequence(queries.map({
-                    case FetchOne(a, ds) => {
-                        val ident = a.asInstanceOf[I]
-                        val task  = M.runQuery(ds.asInstanceOf[DataSource[I, A]].fetchOne(ident))
-                        M.map(task)((r: Option[A]) =>
-                              r.fold(Map.empty[I, A])((result: A) => Map(ident -> result)))
-                      }
-                    case FetchMany(as, ds) =>
-                      M.runQuery(ds
-                            .asInstanceOf[DataSource[I, A]]
-                            .fetchMany(as.asInstanceOf[NonEmptyList[I]]))
-                  }))
-
-                  M.flatMap(sentQueries)((results: List[Map[_, _]]) => {
-                    val endRound = System.nanoTime()
-                    val newCache = (queries zip results).foldLeft(cache)((accache, resultset) => {
-                      val (req, resultmap) = resultset
-                      val ds               = req.dataSource
-                      val tresults         = resultmap.asInstanceOf[Map[I, A]]
-                      val tds              = ds.asInstanceOf[DataSource[I, A]]
-                      accache.cacheResults[I, A](tresults, tds)
-                    })
-
-                    val allFullfilled = (queries zip results).forall({
-                      case (FetchOne(_, _), results)   => results.size == 1
-                      case (FetchMany(as, _), results) => as.toList.size == results.size
-                      case _                           => false
-                    })
-
-                    if (allFullfilled) {
-                      val round = Round(
-                          cache,
-                          Concurrent(queries),
-                          results,
-                          startRound,
-                          endRound
-                      )
-                      val newEnv = env.evolve(round, newCache)
-                      // since user-provided caches may discard elements, we use an in-memory
-                      // cache to gather these intermediate results that will be used for
-                      // concurrent optimizations.
-                      val cachedResults =
-                        (queries zip results).foldLeft(InMemoryCache.empty)((cach, resultSet) => {
-                          val (req, resultmap) = resultSet
-                          val ds               = req.dataSource
-                          val tresults         = resultmap.asInstanceOf[Map[I, A]]
-                          val tds              = ds.asInstanceOf[DataSource[I, A]]
-                          cach.cacheResults[I, A](tresults, tds).asInstanceOf[InMemoryCache]
-                        })
-
-                      M.pure((newEnv, cachedResults.asInstanceOf[A]))
-                    } else {
-                      val missingIdentities: Map[DataSourceName, List[Any]] = (queries zip results)
-                        .collect({
-                          case (FetchOne(id, ds), results) if results.size != 1 =>
-                            ds.name -> List(id)
-                          case (FetchMany(as, ds), results) if results.size != as.toList.size =>
-                            ds.name -> as.toList.collect({
-                              case i if !results.asInstanceOf[Map[Any, Any]].get(i).isDefined => i
-                            })
-                        })
-                        .toMap
-                      M.raiseError(
-                          MissingIdentities(env, missingIdentities)
-                      )
-                    }
-                  })
-                }
-              }
+            case Thrown(e)              => M.raiseError(UnhandledException(e))
+            case Fetched(a)             => M.pure((env, a))
+            case one @ FetchOne(_, _)   => processOne(one, env)
+            case many @ FetchMany(_, _) => processMany(many, env)
+            case conc @ Concurrent(_)   => processConcurrent(conc, env)
           }
         }
+    }
+  }
+
+  private[this] def processOne[M[_], A](
+      one: FetchOne[Any, A],
+      env: FetchEnv
+  )(
+      implicit M: FetchMonadError[M]
+  ): M[(FetchEnv, A)] = {
+    val FetchOne(id, ds) = one
+    val startRound       = System.nanoTime()
+    env.cache
+      .get[A](ds.identity(id))
+      .fold[M[(FetchEnv, A)]](
+          M.runQuery(ds.fetchOne(id)).flatMap { (res: Option[A]) =>
+            val endRound = System.nanoTime()
+            res.fold[M[(FetchEnv, A)]] {
+              // could not get result from datasource
+              M.raiseError(NotFound(env, one))
+            } { result =>
+              // found result (and update cache)
+              val newCache = env.cache.update(ds.identity(id), result)
+              val round    = Round(env.cache, one, result, startRound, endRound)
+              M.pure(env.evolve(round, newCache) -> result)
+            }
+          }
+      ) { cached =>
+        // get result from cache
+        M.pure(env -> cached)
+      }
+  }
+
+  private[this] def processMany[M[_], A](
+      many: FetchMany[Any, Any],
+      env: FetchEnv
+  )(
+      implicit M: FetchMonadError[M],
+      ev: List[Any] =:= A
+  ): M[(FetchEnv, A)] = {
+    val ids        = many.as
+    val ds         = many.ds //.castDS[Any, Any]
+    val startRound = System.nanoTime()
+    val cache      = env.cache
+    val newIds     = many.missingIdentities(cache)
+
+    (for {
+      newIdsNel <- XorT.fromXor[M] {
+                    NonEmptyList.fromList(newIds).toRightXor {
+                      // no missing ids, get all from cache
+                      val cachedResults = ids.toList.mapFilter(id => cache.get(ds.identity(id)))
+                      env -> cachedResults
+                    }
+                  }
+      resMap <- XorT.right(M.runQuery(ds.fetchMany(newIdsNel)))
+      results <- ids.toList
+                  .traverseU(id => resMap.get(id).toValidNel(id))
+                  .fold[XorT[M, (FetchEnv, List[Any]), List[Any]]]({ missingIds =>
+                    // not all identities could be found
+                    val map = Map(ds.name -> missingIds.toList)
+                    XorT.left(M.raiseError(MissingIdentities(env, map)))
+                  }, XorT.pure)
+    } yield {
+      // found all results (and update cache)
+      val endRound = System.nanoTime()
+      val newCache = cache.cacheResults(resMap, ds)
+      val round    = Round(cache, many, results, startRound, endRound)
+      env.evolve(round, newCache) -> results
+    }).merge.map { case (env, l) => (env, ev(l)) } // A =:= List[Any]
+  }
+
+  private[this] def processConcurrent[M[_]](
+      concurrent: Concurrent,
+      env: FetchEnv
+  )(
+      implicit M: FetchMonadError[M]
+  ): M[(FetchEnv, DataSourceCache)] = {
+    def runFetchQueryAsMap[I, A](op: FetchQuery[I, A]): M[Map[I, A]] =
+      op match {
+        case FetchOne(a, ds) =>
+          OptionT(M.runQuery(ds.fetchOne(a))).map(r => Map(a -> r)).getOrElse(Map.empty)
+        case FetchMany(as, ds) => M.runQuery(ds.fetchMany(as))
+      }
+
+    type MissingIdentitiesMap = Map[DataSourceName, List[Any]]
+
+    // Give for a list of queries and result(maps) all the missing identities
+    def missingIdentitiesOrAllFulfilled(
+        queriesAndResults: List[(FetchQuery[Any, Any], Map[Any, Any])]
+    ): Validated[MissingIdentitiesMap, Unit] =
+      queriesAndResults.traverseU_ {
+        case (FetchOne(id, ds), resultMap) =>
+          Either.cond(resultMap.size == 1, (), Map(ds.name -> List(id))).toValidated
+        case (FetchMany(as, ds), resultMap) =>
+          Either
+            .cond(as.toList.size == resultMap.size,
+                  (),
+                  Map(ds.name -> as.toList.filter(id => resultMap.get(id).isEmpty)))
+            .toValidated
+        case _ =>
+          Map.empty[DataSourceName, List[Any]].invalid
+      }
+
+    val startRound = System.nanoTime()
+    val cache      = env.cache
+
+    val queries: List[FetchQuery[Any, Any]] = pendingQueries(concurrent.as, cache)
+
+    if (queries.isEmpty)
+      // there are no pending queries
+      M.pure((env, cache))
+    else {
+      val sentRequests = queries.traverse(r => runFetchQueryAsMap(r))
+
+      sentRequests.flatMap { results =>
+        val endRound          = System.nanoTime()
+        val queriesAndResults = queries zip results
+
+        val missingOrFulfilled = missingIdentitiesOrAllFulfilled(queriesAndResults)
+
+        missingOrFulfilled.fold({ missingIds =>
+          // not all identiies were found
+          M.raiseError(MissingIdentities(env, missingIds))
+        }, { _ =>
+          // results found for all identities
+          val round = Round(cache, Concurrent(queries), results, startRound, endRound)
+
+          // since user-provided caches may discard elements, we use an in-memory
+          // cache to gather these intermediate results that will be used for
+          // concurrent optimizations.
+          val (newCache, cachedResults) =
+            queriesAndResults.foldLeft((cache, InMemoryCache.empty)) {
+              case ((userCache, internCache), (req, resultMap)) =>
+                val anyMap = resultMap.asInstanceOf[Map[Any, Any]]
+                val anyDS  = req.dataSource.castDS[Any, Any]
+                (userCache.cacheResults(anyMap, anyDS),
+                 internCache.cacheResults(anyMap, anyDS).asInstanceOf[InMemoryCache])
+            }
+
+          M.pure((env.evolve(round, newCache), cachedResults))
+        })
       }
     }
   }

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -60,6 +60,7 @@ object TestHelper {
     override def fetchMany(ids: NonEmptyList[Many]): Query[Map[Many, List[Int]]] =
       Query.sync(ids.toList.map(m => (m, 0 until m.n toList)).toMap)
   }
+  def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
 
   case class Never()
   implicit object NeverSource extends DataSource[Never, Int] {
@@ -69,7 +70,6 @@ object TestHelper {
     override def fetchMany(ids: NonEmptyList[Never]): Query[Map[Never, Int]] =
       Query.sync(Map.empty[Never, Int])
   }
-  def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
 
   def requestFetches(r: FetchRequest): Int =
     r match {


### PR DESCRIPTION
- Refactor interpreter: split out handling of `FetchOne`, `FetchMany`
  and `Concurrent`, use `XorT` in `processMany` to reduce nested folds,
  use `Validated` in `processMany` and `processConcurrent` to get
  missing ids/identities or some result.
- (Prematurely ?) optimize `Fetch.join`
- Replaced custom implementations of `map2`, `sequence` and `traverse`
  by using `Applicative[Fetch]`
- ...

I moved some methods around in the `Fetch` object and with the
extraction of the three methods in the interpreter, so the diff looks
much bigger than it actually is.