### PR TITLE
Support a maximum batch size per `DataSource`

### DIFF
--- a/shared/src/main/scala/implicits.scala
+++ b/shared/src/main/scala/implicits.scala
@@ -26,8 +26,7 @@ object implicits extends FutureInstances {
       ME: MonadError[Future, Throwable],
       FM: FlatMap[Future]
   ): FetchMonadError[Future] = new FetchMonadError[Future] {
-    override def tailRecM[A, B](a: A)(
-        f: A => scala.concurrent.Future[Either[A, B]]): scala.concurrent.Future[B] =
+    override def tailRecM[A, B](a: A)(f: A => Future[Either[A, B]]): Future[B] =
       FM.tailRecM(a)(f)
     override def runQuery[A](j: Query[A]): Future[A] = j match {
       case Sync(e) => Future(e.value)


### PR DESCRIPTION
- Add the `maxBatchSizePhase` interpreter which splits fetches to data sources with a maximum batch size in to multiple sequential fetches. This required a change to `Concurrent` to return a `InMemoryCache` instead of a `DataSourceCache` making it possible to combine multiple caches for sequential batches.
- Refactor the `processConcurrent` method which is used in the `coreInterpreter` (previously called `interpreter`) by using `XorT` instead of nested `if` / `else` and `Option.fold` and by extracting some helper methods.
- Give some members of the `Fetch` constructors a better name (eg. `FetchMany.as` to `FetchMany.ids`)
- Create the `Fetch.multiple` method which makes it possible to create a `Fetch[List[...]]` directly (using `FetchMany` underneath). This can currently (and previously) be done by using `sequence` or `traverse`, but `multiple` doesn't have the overhead of inspecting the Fetch structure to find independent fetches which can be parallelized.