### PR TITLE
Aggregates fetch-monix in the root module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val fetchJVM = fetch.jvm
 lazy val fetchJS = fetch.js
 
 lazy val root = project.in(file("."))
-  .aggregate(fetchJS, fetchJVM)
+  .aggregate(fetchJS, fetchJVM, fetchMonixJVM, fetchMonixJS)
   .settings(noPublishSettings)
 
 lazy val docsSettings = ghpages.settings ++ buildSettings ++ tutSettings ++ Seq(


### PR DESCRIPTION
This PR includes `fetch-monix` module as a part of the root module, publishing it with the rest of the modules.

Please, @dialelo review at your convenience. Thanks.