### PR TITLE
Fixes Cross Publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ before_install:
    -in secring.gpg.enc -out secring.gpg -d; fi
 script:
 - sbt coverage 'fetchJVM/test' 'fetchJVM/coverageReport'
-- sbt 'monixJVM/test' 'monixJS/test'
-- sbt 'fetchJS/test'
-- sbt 'docs/tut'
-- sbt 'readme/tut'
+- sbt ++$TRAVIS_SCALA_VERSION 'monixJVM/test' 'monixJS/test'
+- sbt ++$TRAVIS_SCALA_VERSION 'fetchJS/test'
+- sbt ++$TRAVIS_SCALA_VERSION 'docs/tut'
+- sbt ++$TRAVIS_SCALA_VERSION 'readme/tut'
 after_success:
 - bash <(curl -s https://codecov.io/bash) -t 47609994-e0cd-4f3b-a28d-eb558142c3bb
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION
   publishSigned; fi

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ A library for Simple & Efficient data access in Scala and Scala.js
 
 Add the following dependency to your project's build file.
 
-For Scala 2.11.x:
+For Scala 2.11.x and 2.12.x:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0"
+"com.fortysevendeg" %% "fetch" % "0.4.0"
 ```
 
 Or, if using Scala.js (0.6.x):
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0"
+"com.fortysevendeg" %%% "fetch" % "0.4.0"
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val fetchJS = fetch.js
 
 lazy val root = project.in(file("."))
   .aggregate(fetchJS, fetchJVM, fetchMonixJVM, fetchMonixJS)
+  .settings(allSettings)
   .settings(noPublishSettings)
 
 lazy val docsSettings = ghpages.settings ++ buildSettings ++ tutSettings ++ Seq(

--- a/docs/src/tut/docs.md
+++ b/docs/src/tut/docs.md
@@ -29,13 +29,13 @@ we read) concerns.
 To begin, add the following dependency to your SBT build file:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0"
+"com.fortysevendeg" %% "fetch" % "0.4.0"
 ```
 
 Or, if using Scala.js:
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0"
+"com.fortysevendeg" %%% "fetch" % "0.4.0"
 ```
 
 Now you'll have Fetch available in both Scala and Scala.js.
@@ -645,6 +645,7 @@ When a single identity is being fetched the request will be a `FetchOne`; it con
 should be able to easily diagnose the failure. For ilustrating this scenario we'll ask for users that are not in the database.
 
 ```tut:silent
+import cats.syntax.either._
 val missingUser = getUser(5)
 val eval: Eval[Either[FetchException, User]] = missingUser.runA[Eval].attempt
 val result: Either[FetchException, User] = eval.value
@@ -940,7 +941,7 @@ The [Monix](https://monix.io/) library provides an abstraction for lazy, asynchr
 For using `Task` as the target concurrency monad of a fetch, add the following dependency to your build file:
 
 ```scala
-"com.fortysevendeg" %% "fetch-monix" % "0.3.0"
+"com.fortysevendeg" %% "fetch-monix" % "0.4.0"
 ```
 
 And do some standard imports, we'll need an Scheduler for running our tasks as well as the instance of `FetchMonadError[Task]` that `fetch-monix` provides:

--- a/docs/src/tut/index.md
+++ b/docs/src/tut/index.md
@@ -10,16 +10,16 @@ technologies:
 
 Add the following dependency to your project's build file.
 
-For Scala 2.11.x:
+For Scala 2.11.x and 2.12.x:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0"
+"com.fortysevendeg" %% "fetch" % "0.4.0"
 ```
 
 Or, if using Scala.js (0.6.x):
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0"
+"com.fortysevendeg" %%% "fetch" % "0.4.0"
 ```
 
 ```tut:invisible

--- a/tut/README.md
+++ b/tut/README.md
@@ -12,16 +12,16 @@ A library for Simple & Efficient data access in Scala and Scala.js
 
 Add the following dependency to your project's build file.
 
-For Scala 2.11.x:
+For Scala 2.11.x and 2.12.x:
 
 ```scala
-"com.fortysevendeg" %% "fetch" % "0.3.0"
+"com.fortysevendeg" %% "fetch" % "0.4.0"
 ```
 
 Or, if using Scala.js (0.6.x):
 
 ```scala
-"com.fortysevendeg" %%% "fetch" % "0.3.0"
+"com.fortysevendeg" %%% "fetch" % "0.4.0"
 ```
 
 ```tut:invisible


### PR DESCRIPTION
I've just realized we should cross-publish with `+publishSigned` instead of just `publishSigned`, now that we have cross compatibility through scala `2.11` and `2.12`. Also, if we don't apply `allSettings` to the root project, the cross versioning starts with scala `2.10`.

This PR comes to fix it. 

@dialelo  @peterneyens  could you take a look? Thanks!