### PR TITLE
Update Cats and Monix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ lazy val buildSettings = Seq(
   startYear := Option(2016),
   homepage := Option(url("http://47deg.github.io/fetch/")),
   organizationHomepage := Option(new URL("http://47deg.com")),
-  scalaVersion := "2.12.0",
-  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
+  scalaVersion := "2.12.1",
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
   libraryDependencies ++= (scalaBinaryVersion.value match {
     case "2.10" =>
       compilerPlugin("org.scalamacros" % "paradise" % versions("paradise") cross CrossVersion.full) :: Nil
@@ -160,13 +160,13 @@ lazy val debugJVM = debug.jvm
 lazy val debugJS  = debug.js
 
 lazy val examplesSettings = Seq(
-  scalaVersion := "2.12.0",
+  scalaVersion := "2.12.1",
   libraryDependencies ++= Seq(
-    "org.tpolecat" %% "doobie-core-cats"    % "0.3.1-M2",
-    "org.tpolecat" %% "doobie-h2-cats"      % "0.3.1-M2",
-    "org.http4s"   %% "http4s-blaze-client" % "0.15.0a",
-    "org.http4s"   %% "http4s-circe"        % "0.15.0a",
-    "io.circe"     %% "circe-generic"       % "0.6.1"
+    "org.tpolecat" %% "doobie-core-cats"    % versions("doobie"),
+    "org.tpolecat" %% "doobie-h2-cats"      % versions("doobie"),
+    "org.http4s"   %% "http4s-blaze-client" % versions("http4s"),
+    "org.http4s"   %% "http4s-circe"        % versions("http4s"),
+    "io.circe"     %% "circe-generic"       % versions("circe")
   )
 )
 

--- a/examples/src/test/scala/DoobieExample.scala
+++ b/examples/src/test/scala/DoobieExample.scala
@@ -63,8 +63,8 @@ class DoobieExample extends AsyncWordSpec with Matchers {
       sql"SELECT * FROM author WHERE id = $id".query[Author].option
 
     def fetchByIds(ids: NonEmptyList[AuthorId]): ConnectionIO[List[Author]] = {
-      implicit val idsParam = Param.many(ids)
-      sql"SELECT * FROM author WHERE id IN (${ids: ids.type})".query[Author].list
+      val q = fr"SELECT * FROM author WHERE" ++ Fragments.in(fr"id", ids)
+      q.query[Author].list
     }
 
     implicit val authorIdMeta: Meta[AuthorId] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.4.8")
-addSbtPlugin("com.fortysevendeg" % "sbt-catalysts-extras" % "0.1.1")
-addSbtPlugin("com.fortysevendeg" % "sbt-microsites" % "0.3.3")
+addSbtPlugin("com.fortysevendeg" % "sbt-catalysts-extras" % "0.1.3")


### PR DESCRIPTION
Some code clean up using `Reducible#reduceMapM` and the now covariant `NonEmptyList`.

The http4s-circe version still depends on circe 0.6.1 and thus cats 0.8.1. It is only used in the example project of Fetch, so it doesn't matter here, but we should probably update sbt-catalysts-extras once a new http4s version comes out.

Resolves #98 