### PR TITLE
Set version to 0.5.0 for publishing under new group id

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1-SNAPSHOT"
+version in ThisBuild := "0.5.0"


### PR DESCRIPTION
Since the org was renamed after 0.5.0 was published, we need to release the 0.5.0 artifacts with the new organization name. Merging this PR in master will publish them automatically.

Closes #103