### PR TITLE
Add curried apply to Fetch object

### DIFF
--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -138,6 +138,11 @@ object `package` {
 
   object Fetch extends FetchInterpreters {
 
+    class PartialApply[A]{def apply[I](i:I)(implicit DS: DataSource[I, A]): Fetch[A] = Fetch(i)}
+
+    def apply[A]: PartialApply[A] =
+      new PartialApply[A]
+
     /**
       * Lift a plain value to the Fetch monad.
       */

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -189,6 +189,11 @@ class FetchTests extends AsyncFreeSpec with Matchers {
 
   implicit override def executionContext = ExecutionContext.Implicits.global
 
+  "We can fetch using partial application" in {
+    val fetch = Fetch[Int](One(1))
+    Fetch.run[Future](fetch).map(_ shouldEqual 1)
+  }
+
   "We can lift plain values to Fetch" in {
     val fetch: Fetch[Int] = Fetch.pure(42)
     Fetch.run[Future](fetch).map(_ shouldEqual 42)


### PR DESCRIPTION
very minor convenience, allows users to do

```scala
def getUser(id: UserId) = Fetch[User](id)
```