### PR TITLE
add batchingOnly convenience method

### DIFF
--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -57,5 +57,8 @@ trait DataSource[I, A] {
     ids.toList.traverseFilter(fetchOneWithId).map(_.toMap)
   }
 
+  def batchingOnly(id: I): Query[Option[A]] =
+    fetchMany(NonEmptyList.of(id)).map(_ get id)
+      
   def maxBatchSize: Option[Int] = None
 }


### PR DESCRIPTION
- similarly to batchingNotSupported, but for sources that only do
batching (or for which batching is just as natural)