### PR TITLE
Allow sequential and parallel batches

### DIFF
--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -59,6 +59,12 @@ trait DataSource[I, A] {
 
   def batchingOnly(id: I): Query[Option[A]] =
     fetchMany(NonEmptyList.of(id)).map(_ get id)
-      
+
   def maxBatchSize: Option[Int] = None
+
+  def batchExecution: ExecutionType = Parallel
 }
+
+sealed trait ExecutionType extends Product with Serializable
+case object Sequential extends ExecutionType
+case object Parallel extends ExecutionType

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -138,7 +138,9 @@ object `package` {
 
   object Fetch extends FetchInterpreters {
 
-    class PartialApply[A]{def apply[I](i:I)(implicit DS: DataSource[I, A]): Fetch[A] = Fetch(i)}
+    class PartialApply[A] {
+      def apply[I](i: I)(implicit DS: DataSource[I, A]): Fetch[A] = Fetch(i)
+    }
 
     def apply[A]: PartialApply[A] =
       new PartialApply[A]

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -247,6 +247,8 @@ trait FetchInterpreters {
   private[this] def batchMany[I, A](many: FetchMany[I, A]): Fetch[List[A]] = {
     val batchedFetches = manyInBatches(many)
     many.ds.batchExecution match {
+      case _ if many.ds.maxBatchSize.isEmpty =>
+        Free.liftF(many)
       case Sequential =>
         batchedFetches.reduceMapM[Fetch, List[A]](Free.liftF(_))
       case Parallel =>

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -19,24 +19,9 @@ package fetch
 import scala.collection.immutable._
 
 import cats.{Applicative, ApplicativeError, Id, Monad, MonadError, Semigroup, ~>}
-import cats.data.{Coproduct, EitherT, NonEmptyList, OptionT, StateT, Validated, ValidatedNel}
+import cats.data.{Coproduct, EitherT, Ior, NonEmptyList, OptionT, StateT, Validated, ValidatedNel}
 import cats.free.Free
-import cats.instances.option._
-import cats.instances.list._
-import cats.instances.map._
-import cats.instances.tuple._
-import cats.syntax.cartesian._
-import cats.syntax.either._
-import cats.syntax.flatMap._
-import cats.syntax.foldable._
-import cats.syntax.functor._
-import cats.syntax.functorFilter._
-import cats.syntax.list._
-import cats.syntax.option._
-import cats.syntax.reducible._
-import cats.syntax.semigroup._
-import cats.syntax.traverse._
-import cats.syntax.validated._
+import cats.implicits._
 
 import cats.free.FreeTopExt
 
@@ -261,18 +246,41 @@ trait FetchInterpreters {
 
   private[this] def batchMany[I, A](many: FetchMany[I, A]): Fetch[List[A]] = {
     val batchedFetches = manyInBatches(many)
-    batchedFetches.reduceMapM[Fetch, List[A]](Free.liftF[FetchOp, List[A]])
+    many.ds.batchExecution match {
+      case Sequential =>
+        batchedFetches.reduceMapM[Fetch, List[A]](Free.liftF(_))
+      case Parallel =>
+        val queries = batchedFetches.asInstanceOf[NonEmptyList[FetchQuery[Any, Any]]]
+        Free.liftF(Concurrent(queries)).map { results =>
+          many.ids.toList.mapFilter(id => results.get(many.ds.identity(id)))
+        }
+    }
   }
 
   private[this] def batchConcurrent(conc: Concurrent): Fetch[InMemoryCache] = {
     type Batch = NonEmptyList[FetchQuery[Any, Any]]
     val Concurrent(fetches) = conc
-    val individualBatches: NonEmptyList[Batch] = fetches.map {
-      case many @ FetchMany(_, _) => manyInBatches(many)
-      case other                  => NonEmptyList.of(other)
-    }
-    val batchedConcurrents = transposeNelsUnequalLengths(individualBatches).map(Concurrent(_))
-    batchedConcurrents.reduceMapM[Fetch, InMemoryCache](Free.liftF(_))
+
+    val parIorSeqBatches: Ior[Batch, NonEmptyList[Batch]] =
+      fetches.reduceMap {
+        case many @ FetchMany(_, ds) =>
+          val batches = manyInBatches(many)
+          many.ds.batchExecution match {
+            case Parallel   => Ior.left(batches)
+            case Sequential => Ior.right(NonEmptyList.of(batches))
+          }
+        case other =>
+          Ior.left(NonEmptyList.of(other))
+      }
+
+    val batches: NonEmptyList[Batch] =
+      parIorSeqBatches.map(transposeNelsUnequalLengths) match {
+        case Ior.Left(par)       => NonEmptyList.of(par)
+        case Ior.Right(seqs)     => seqs
+        case Ior.Both(par, seqs) => NonEmptyList(par <+> seqs.head, seqs.tail)
+      }
+
+    batches.map(Concurrent(_)).reduceMapM[Fetch, InMemoryCache](Free.liftF(_))
   }
 
   private[fetch] def transposeNelsUnequalLengths[A](


### PR DESCRIPTION
I made it possible to configure if you want to execute batches to a data source sequentially or in parallel.

By default they will be parallel, so we should mention in the next release notes that people relying on the sequential execution of the batches should update their data sources to specify this sequential execution.