### PR TITLE
Integrates sbt-org-policies plugin

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,22 @@
 style = defaultWithAlign
 maxColumn = 100
+
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+docstrings = JavaDoc
+
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.maxLines = 1
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ before_install:
    -K $encrypted_37b99bd39158_key -iv $encrypted_37b99bd39158_iv
    -in secring.gpg.enc -out secring.gpg -d; fi
 script:
-- sbt coverage 'fetchJVM/test' 'fetchJVM/coverageReport'
-- sbt ++$TRAVIS_SCALA_VERSION 'tests/test'
+- sbt ++$TRAVIS_SCALA_VERSION compile test
+- sbt ++$TRAVIS_SCALA_VERSION coverage 'fetchJVM/test' 'fetchJVM/coverageReport'
 - sbt ++$TRAVIS_SCALA_VERSION 'docs/tut'
 - sbt ++$TRAVIS_SCALA_VERSION 'readme/tut'
 - sbt 'examples/test'
 after_success:
 - bash <(curl -s https://codecov.io/bash) -t 47609994-e0cd-4f3b-a28d-eb558142c3bb
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION
-  publishSigned; fi
+- sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
 - 2.10.6
-- 2.11.8
-- 2.12.0
+- 2.11.11
+- 2.12.2
 jdk:
 - oraclejdk8
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
-## Changelog
+# Changelog
 
-## Version 0.6.0
-
-Date: 2017-03-17
+## 2017-03-17 - Version 0.6.0
 
 - Add `DataSource#batchingOnly` for batch-only data sources (thanks @aleczorab)
 - Add `DataSource#batchExecution` for controlling how batches are executed
-
 
 ## Version 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Let's run it and wait for the fetch to complete:
 
 ```scala
 fetchOne.runA[Id]
-// [554] One ToString 1
+// [132] One ToString 1
 // res3: cats.Id[String] = 1
 ```
 
@@ -118,7 +118,7 @@ When executing the above fetch, note how the three identities get batched and th
 
 ```scala
 fetchThree.runA[Id]
-// [554] Many ToString NonEmptyList(1, 2, 3)
+// [132] Many ToString NonEmptyList(3, 1, 2)
 // res5: cats.Id[(String, String, String)] = (1,2,3)
 ```
 
@@ -159,8 +159,8 @@ Note how the two independent data fetches run in parallel, minimizing the latenc
 
 ```scala
 fetchMulti.runA[Id]
-// [554] One ToString 1
-// [555] One Length one
+// [133] One Length one
+// [132] One ToString 1
 // res7: cats.Id[(String, Int)] = (1,3)
 ```
 
@@ -179,6 +179,6 @@ While running it, notice that the data source is only queried once. The next tim
 
 ```scala
 fetchTwice.runA[Id]
-// [554] One ToString 1
+// [132] One ToString 1
 // res8: cats.Id[(String, String)] = (1,1)
 ```

--- a/debug/shared/src/main/scala/debug.scala
+++ b/debug/shared/src/main/scala/debug.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/debug/shared/src/main/scala/document.scala
+++ b/debug/shared/src/main/scala/document.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/DoobieExample.scala
+++ b/examples/src/test/scala/DoobieExample.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.syntax.cartesian._
@@ -54,9 +70,12 @@ class DoobieExample extends AsyncWordSpec with Matchers {
       }
     override def fetchMany(ids: NonEmptyList[AuthorId]): Query[Map[AuthorId, Author]] =
       Query.async { (ok, fail) =>
-        fetchByIds(ids).map { authors =>
-          authors.map(a => AuthorId(a.id) -> a).toMap
-        }.transact(xa).unsafeRunAsync(_.fold(fail, ok))
+        fetchByIds(ids)
+          .map { authors =>
+            authors.map(a => AuthorId(a.id) -> a).toMap
+          }
+          .transact(xa)
+          .unsafeRunAsync(_.fold(fail, ok))
       }
 
     def fetchById(id: AuthorId): ConnectionIO[Option[Author]] =

--- a/jvm/src/main/scala/unsafeImplicits.scala
+++ b/jvm/src/main/scala/unsafeImplicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package fetch.unsafe
 
 import fetch._
 
-import cats.{Id, Eval, FlatMap}
+import cats.{Eval, FlatMap, Id}
 import cats.syntax.either._
 
 import scala.concurrent._

--- a/monix/shared/src/main/scala/monix.scala
+++ b/monix/shared/src/main/scala/monix.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/monix/shared/src/test/scala/FetchTaskTests.scala
+++ b/monix/shared/src/test/scala/FetchTaskTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -73,9 +73,9 @@ object ProjectPlugin extends AutoPlugin {
       startYear := Option(2016),
       homepage := Option(url("http://47deg.github.io/fetch/")),
       organizationHomepage := Option(new URL("http://47deg.com")),
-      scalaVersion := "2.12.1",
       scalaOrganization := "org.scala-lang",
-      crossScalaVersions := "2.10.6" :: scalac.crossScalaVersions,
+      scalaVersion := "2.12.2",
+      crossScalaVersions := List("2.10.6", "2.11.11", "2.12.2"),
       resolvers += Resolver.sonatypeRepo("snapshots"),
       scalacOptions := Seq(
         "-unchecked",
@@ -91,7 +91,6 @@ object ProjectPlugin extends AutoPlugin {
           compilerPlugin(%%("paradise") cross CrossVersion.full) :: Nil
         case _ =>
           Nil
-      }),
-      orgGithubTokenSetting := "GITHUB_TOKEN_REPO"
+      })
     ) ++ shellPromptSettings
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -62,8 +62,7 @@ object ProjectPlugin extends AutoPlugin {
       %%("doobie-core-cats"),
       %%("doobie-h2-cats"),
       %%("http4s-blaze-client"),
-      %%("http4s-circe"),
-      %%("scalaz-concurrent")
+      %%("http4s-circe")
     ) ++ commonCrossDependencies
   }
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,0 +1,97 @@
+import microsites.MicrositesPlugin.autoImport._
+import com.typesafe.sbt.site.SitePlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import sbtorgpolicies.OrgPoliciesPlugin
+import sbtorgpolicies.model._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
+import tut.Plugin._
+
+object ProjectPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = OrgPoliciesPlugin
+
+  object autoImport {
+
+    lazy val commonCrossDependencies: Seq[ModuleID] = Seq(%%("cats-free"), %%("scalatest") % "test")
+
+    lazy val monixCrossDependencies: Seq[ModuleID] = Seq(%%("monix-eval"), %%("monix-cats"))
+
+    lazy val micrositeSettings: Seq[Def.Setting[_]] = Seq(
+      micrositeName := "Fetch",
+      micrositeDescription := "Simple & Efficient data access for Scala and Scala.js",
+      micrositeBaseUrl := "fetch",
+      micrositeDocumentationUrl := "/fetch/docs.html",
+      micrositeGithubOwner := "47deg",
+      micrositeGithubRepo := "fetch",
+      micrositeHighlightTheme := "tomorrow",
+      micrositePalette := Map(
+        "brand-primary"   -> "#FF518C",
+        "brand-secondary" -> "#2F2859",
+        "brand-tertiary"  -> "#28224C",
+        "gray-dark"       -> "#48474C",
+        "gray"            -> "#8D8C92",
+        "gray-light"      -> "#E3E2E3",
+        "gray-lighter"    -> "#F4F3F9",
+        "white-color"     -> "#FFFFFF"
+      ),
+      includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md"
+    )
+
+    lazy val commonTutSettings: Seq[Def.Setting[_]] = Seq(
+      tutScalacOptions ~= (_.filterNot(Set("-Ywarn-unused-import", "-Ywarn-dead-code"))),
+      tutScalacOptions ++= (scalaBinaryVersion.value match {
+        case "2.10" => Seq("-Xdivergence211")
+        case _      => Nil
+      })
+    )
+
+    lazy val docsSettings: Seq[Def.Setting[_]] = micrositeSettings ++ commonTutSettings ++ Seq(
+      aggregate in doc := true)
+
+    lazy val readmeSettings: Seq[Def.Setting[_]] = tutSettings ++ commonTutSettings ++ Seq(
+      tutSourceDirectory := baseDirectory.value,
+      tutTargetDirectory := baseDirectory.value.getParentFile,
+      tutNameFilter := """README.md""".r
+    )
+
+    lazy val examplesSettings: Seq[Def.Setting[_]] = libraryDependencies ++= Seq(
+      %%("circe-generic"),
+      %%("doobie-core-cats"),
+      %%("doobie-h2-cats"),
+      %%("http4s-blaze-client"),
+      %%("http4s-circe"),
+      %%("scalaz-concurrent")
+    ) ++ commonCrossDependencies
+  }
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      description := "Simple & Efficient data access for Scala and Scala.js",
+      startYear := Option(2016),
+      homepage := Option(url("http://47deg.github.io/fetch/")),
+      organizationHomepage := Option(new URL("http://47deg.com")),
+      scalaVersion := "2.12.1",
+      scalaOrganization := "org.scala-lang",
+      crossScalaVersions := "2.10.6" :: scalac.crossScalaVersions,
+      resolvers += Resolver.sonatypeRepo("snapshots"),
+      scalacOptions := Seq(
+        "-unchecked",
+        "-deprecation",
+        "-feature",
+        "-Ywarn-dead-code",
+        "-language:higherKinds",
+        "-language:existentials",
+        "-language:postfixOps"
+      ),
+      libraryDependencies ++= (scalaBinaryVersion.value match {
+        case "2.10" =>
+          compilerPlugin(%%("paradise") cross CrossVersion.full) :: Nil
+        case _ =>
+          Nil
+      }),
+      orgGithubTokenSetting := "GITHUB_TOKEN_REPO"
+    ) ++ shellPromptSettings
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-# sbt.version=0.13.13  no scalafmt
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.10")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.11")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.4.8")
-addSbtPlugin("com.fortysevendeg" % "sbt-catalysts-extras" % "0.1.3")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.10")

--- a/shared/src/main/scala/FetchMonadError.scala
+++ b/shared/src/main/scala/FetchMonadError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/cache.scala
+++ b/shared/src/main/scala/cache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/env.scala
+++ b/shared/src/main/scala/env.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,8 +79,8 @@ sealed trait FetchQuery[I, A] extends FetchRequest {
 }
 
 /**
-  * Primitive operations in the Fetch Free monad.
-  */
+ * Primitive operations in the Fetch Free monad.
+ */
 sealed abstract class FetchOp[A] extends Product with Serializable
 
 final case class FetchOne[I, A](id: I, ds: DataSource[I, A])
@@ -139,65 +139,65 @@ object `package` {
   object Fetch extends FetchInterpreters {
 
     /**
-      * Lift a plain value to the Fetch monad.
-      */
+     * Lift a plain value to the Fetch monad.
+     */
     def pure[A](a: A): Fetch[A] =
       Free.pure(a)
 
     /**
-      * Lift an exception to the Fetch monad.
-      */
+     * Lift an exception to the Fetch monad.
+     */
     def error[A](e: Throwable): Fetch[A] =
       Free.liftF(Thrown(e))
 
     /**
-      * Given a value that has a related `DataSource` implementation, lift it
-      * to the `Fetch` monad. When executing the fetch the data source will be
-      * queried and the fetch will return its result.
-      */
+     * Given a value that has a related `DataSource` implementation, lift it
+     * to the `Fetch` monad. When executing the fetch the data source will be
+     * queried and the fetch will return its result.
+     */
     def apply[I, A](i: I)(
         implicit DS: DataSource[I, A]
     ): Fetch[A] =
       Free.liftF(FetchOne[I, A](i, DS))
 
     /**
-      * Given multiple values with a related `DataSource` lift them to the `Fetch` monad.
-      */
+     * Given multiple values with a related `DataSource` lift them to the `Fetch` monad.
+     */
     def multiple[I, A](i: I, is: I*)(implicit DS: DataSource[I, A]): Fetch[List[A]] =
       Free.liftF(FetchMany(NonEmptyList(i, is.toList), DS))
 
     /**
-      * Given a non empty list of `FetchQuery`s, lift it to the `Fetch` monad. When executing
-      * the fetch, data sources will be queried and the fetch will return an `InMemoryCache`
-      * containing the results.
-      */
+     * Given a non empty list of `FetchQuery`s, lift it to the `Fetch` monad. When executing
+     * the fetch, data sources will be queried and the fetch will return an `InMemoryCache`
+     * containing the results.
+     */
     private[fetch] def concurrently(
         queries: NonEmptyList[FetchQuery[Any, Any]]): Fetch[InMemoryCache] =
       Free.liftF(Concurrent(queries))
 
     /**
-      * Transform a list of fetches into a fetch of a list. It implies concurrent execution of fetches.
-      */
+     * Transform a list of fetches into a fetch of a list. It implies concurrent execution of fetches.
+     */
     def sequence[I, A](ids: List[Fetch[A]]): Fetch[List[A]] =
       Applicative[Fetch].sequence(ids)
 
     /**
-      * Apply a fetch-returning function to every element in a list and return a Fetch of the list of
-      * results. It implies concurrent execution of fetches.
-      */
+     * Apply a fetch-returning function to every element in a list and return a Fetch of the list of
+     * results. It implies concurrent execution of fetches.
+     */
     def traverse[A, B](ids: List[A])(f: A => Fetch[B]): Fetch[List[B]] =
       Applicative[Fetch].traverse(ids)(f)
 
     /**
-      * Apply the given function to the result of the two fetches. It implies concurrent execution of fetches.
-      */
+     * Apply the given function to the result of the two fetches. It implies concurrent execution of fetches.
+     */
     def map2[A, B, C](f: (A, B) => C)(fa: Fetch[A], fb: Fetch[B]): Fetch[C] =
       Applicative[Fetch].map2(fa, fb)(f)
 
     /**
-      * Join two fetches from any data sources and return a Fetch that returns a tuple with the two
-      * results. It implies concurrent execution of fetches.
-      */
+     * Join two fetches from any data sources and return a Fetch that returns a tuple with the two
+     * results. It implies concurrent execution of fetches.
+     */
     def join[A, B](fl: Fetch[A], fr: Fetch[B]): Fetch[(A, B)] =
       Free.liftF(Join(fl, fr))
 
@@ -212,9 +212,9 @@ object `package` {
     }
 
     /**
-      * Run a `Fetch` with the given cache, returning a pair of the final environment and result
-      * in the monad `M`.
-      */
+     * Run a `Fetch` with the given cache, returning a pair of the final environment and result
+     * in the monad `M`.
+     */
     def runFetch[M[_]]: FetchRunner[M] = new FetchRunner[M]
 
     class FetchRunnerEnv[M[_]] {
@@ -228,8 +228,8 @@ object `package` {
     }
 
     /**
-      * Run a `Fetch` with the given cache, returning the final environment in the monad `M`.
-      */
+     * Run a `Fetch` with the given cache, returning the final environment in the monad `M`.
+     */
     def runEnv[M[_]]: FetchRunnerEnv[M] = new FetchRunnerEnv[M]
 
     class FetchRunnerA[M[_]] {
@@ -243,8 +243,8 @@ object `package` {
     }
 
     /**
-      * Run a `Fetch` with the given cache, the result in the monad `M`.
-      */
+     * Run a `Fetch` with the given cache, the result in the monad `M`.
+     */
     def run[M[_]]: FetchRunnerA[M] = new FetchRunnerA[M]
   }
 

--- a/shared/src/main/scala/freeinspect.scala
+++ b/shared/src/main/scala/freeinspect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/implicits.scala
+++ b/shared/src/main/scala/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/interpreters.scala
+++ b/shared/src/main/scala/interpreters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/scala/syntax.scala
+++ b/shared/src/main/scala/syntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/scala/FetchAsyncQueryTests.scala
+++ b/shared/src/test/scala/FetchAsyncQueryTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/scala/FetchBatchingTests.scala
+++ b/shared/src/test/scala/FetchBatchingTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/scala/FetchReportingTests.scala
+++ b/shared/src/test/scala/FetchReportingTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/scala/FetchSyntaxTests.scala
+++ b/shared/src/test/scala/FetchSyntaxTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.0"
+version in ThisBuild := "0.6.1"


### PR DESCRIPTION
This PR migrates from `sbt-catalyst-extras` to `sbt-org-policies` plugin, upgrading all the dependencies.

It also:

* Migrates the http4s-scalaz example to http4s-fs2-cats.
* Fixes https://github.com/47deg/fetch/issues/112 .
* Provides some scalafmt format changes.
* Updates the license headers.

Please, @raulraja @dialelo @peterneyens  could you review? Thanks!
