### PR TITLE
Move and reuse TestHelper

### DIFF
--- a/monix/shared/src/test/scala/FetchTaskTests.scala
+++ b/monix/shared/src/test/scala/FetchTaskTests.scala
@@ -19,7 +19,6 @@ package fetch.monixTask
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{AsyncFreeSpec, Matchers}
-import cats.data.NonEmptyList
 import cats.instances.list._
 import scala.concurrent.Future
 
@@ -27,39 +26,9 @@ import fetch._
 import fetch.monixTask.implicits._
 
 class FetchTaskTests extends AsyncFreeSpec with Matchers {
+  import TestHelper._
+
   implicit override val executionContext = Scheduler.Implicits.global
-
-  case class ArticleId(id: Int)
-  case class Article(id: Int, content: String) {
-    def author: Int = id + 1
-  }
-
-  implicit object ArticleFuture extends DataSource[ArticleId, Article] {
-    override def name = "ArticleFuture"
-    override def fetchOne(id: ArticleId): Query[Option[Article]] =
-      Query.async((ok, fail) => {
-        ok(Option(Article(id.id, "An article with id " + id.id)))
-      })
-    override def fetchMany(ids: NonEmptyList[ArticleId]): Query[Map[ArticleId, Article]] =
-      batchingNotSupported(ids)
-  }
-
-  def article(id: Int): Fetch[Article] = Fetch(ArticleId(id))
-
-  case class AuthorId(id: Int)
-  case class Author(id: Int, name: String)
-
-  implicit object AuthorFuture extends DataSource[AuthorId, Author] {
-    override def name = "AuthorFuture"
-    override def fetchOne(id: AuthorId): Query[Option[Author]] =
-      Query.async((ok, fail) => {
-        ok(Option(Author(id.id, "@egg" + id.id)))
-      })
-    override def fetchMany(ids: NonEmptyList[AuthorId]): Query[Map[AuthorId, Author]] =
-      batchingNotSupported(ids)
-  }
-
-  def author(a: Article): Fetch[Author] = Fetch(AuthorId(a.author))
 
   "We can interpret an async fetch into a task" in {
     val fetch: Fetch[Article] = article(1)

--- a/shared/src/test/scala/FetchBatchingTests.scala
+++ b/shared/src/test/scala/FetchBatchingTests.scala
@@ -16,19 +16,14 @@
 
 package fetch
 
-import scala.concurrent._
-import scala.concurrent.duration._
-
-import org.scalatest._
-
-import cats.MonadError
+import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.{AsyncFreeSpec, Matchers}
 import cats.data.NonEmptyList
 import cats.instances.list._
-
-import fetch._
-import fetch.implicits._
 import cats.syntax.cartesian._
 import cats.syntax.foldable._
+import fetch._
+import fetch.implicits._
 
 class FetchBatchingTests extends AsyncFreeSpec with Matchers {
   import TestHelper._

--- a/shared/src/test/scala/FetchReportingTests.scala
+++ b/shared/src/test/scala/FetchReportingTests.scala
@@ -16,22 +16,16 @@
 
 package fetch
 
-import scala.concurrent._
-import scala.concurrent.duration._
-
-import org.scalatest._
-
-import cats.MonadError
-import cats.data.NonEmptyList
+import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.{AsyncFreeSpec, Matchers}
 import cats.instances.list._
-
 import fetch._
 import fetch.implicits._
 
 class FetchReportingTests extends AsyncFreeSpec with Matchers {
   import TestHelper._
 
-  val ME = implicitly[FetchMonadError[Future]]
+  val ME = FetchMonadError[Future]
 
   implicit override def executionContext = ExecutionContext.Implicits.global
 

--- a/shared/src/test/scala/FetchSyntaxTests.scala
+++ b/shared/src/test/scala/FetchSyntaxTests.scala
@@ -16,15 +16,9 @@
 
 package fetch
 
-import scala.concurrent._
-import scala.concurrent.duration._
-
-import org.scalatest._
-
-import cats.MonadError
-import cats.data.NonEmptyList
+import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.{AsyncFreeSpec, Matchers}
 import cats.instances.list._
-
 import fetch._
 import fetch.implicits._
 
@@ -32,7 +26,7 @@ class FetchSyntaxTests extends AsyncFreeSpec with Matchers {
   import fetch.syntax._
   import TestHelper._
 
-  val ME = implicitly[FetchMonadError[Future]]
+  val ME = FetchMonadError[Future]
 
   implicit override def executionContext = ExecutionContext.Implicits.global
 

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -16,12 +16,9 @@
 
 package fetch
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.{AsyncFreeSpec, Matchers}
 
-import org.scalatest._
-
-import cats.MonadError
 import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.syntax.cartesian._
@@ -29,79 +26,10 @@ import cats.syntax.cartesian._
 import fetch._
 import fetch.implicits._
 
-object TestHelper {
-  import fetch.syntax._
-
-  case class DidNotFound() extends Throwable
-
-  case class One(id: Int)
-  implicit object OneSource extends DataSource[One, Int] {
-    override def name = "OneSource"
-    override def fetchOne(id: One): Query[Option[Int]] =
-      Query.sync(Option(id.id))
-    override def fetchMany(ids: NonEmptyList[One]): Query[Map[One, Int]] =
-      Query.sync(ids.toList.map(one => (one, one.id)).toMap)
-  }
-  def one(id: Int): Fetch[Int] = Fetch(One(id))
-
-  case class AnotherOne(id: Int)
-  implicit object AnotheroneSource extends DataSource[AnotherOne, Int] {
-    override def name = "AnotherOneSource"
-    override def fetchOne(id: AnotherOne): Query[Option[Int]] =
-      Query.sync(Option(id.id))
-    override def fetchMany(ids: NonEmptyList[AnotherOne]): Query[Map[AnotherOne, Int]] =
-      Query.sync(ids.toList.map(anotherone => (anotherone, anotherone.id)).toMap)
-  }
-  def anotherOne(id: Int): Fetch[Int] = Fetch(AnotherOne(id))
-
-  case class Many(n: Int)
-  implicit object ManySource extends DataSource[Many, List[Int]] {
-    override def name = "ManySource"
-    override def fetchOne(id: Many): Query[Option[List[Int]]] =
-      Query.sync(Option(0 until id.n toList))
-    override def fetchMany(ids: NonEmptyList[Many]): Query[Map[Many, List[Int]]] =
-      Query.sync(ids.toList.map(m => (m, 0 until m.n toList)).toMap)
-  }
-  def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
-
-  case class Never()
-  implicit object NeverSource extends DataSource[Never, Int] {
-    override def name = "NeverSource"
-    override def fetchOne(id: Never): Query[Option[Int]] =
-      Query.sync(None)
-    override def fetchMany(ids: NonEmptyList[Never]): Query[Map[Never, Int]] =
-      Query.sync(Map.empty[Never, Int])
-  }
-
-  def requestFetches(r: FetchRequest): Int =
-    r match {
-      case FetchOne(_, _)       => 1
-      case FetchMany(ids, _)    => ids.toList.size
-      case Concurrent(requests) => requests.toList.map(requestFetches).sum
-    }
-
-  def totalFetched(rs: Seq[Round]): Int =
-    rs.map((round: Round) => requestFetches(round.request)).toList.sum
-
-  def requestBatches(r: FetchRequest): Int =
-    r match {
-      case FetchOne(_, _)    => 0
-      case FetchMany(ids, _) => 1
-      case Concurrent(requests) =>
-        requests.toList.count {
-          case FetchMany(_, _) => true
-          case _               => false
-        }
-    }
-
-  def totalBatches(rs: Seq[Round]): Int =
-    rs.map((round: Round) => requestBatches(round.request)).toList.sum
-}
-
 class FetchTests extends AsyncFreeSpec with Matchers {
   import TestHelper._
 
-  val ME = implicitly[FetchMonadError[Future]]
+  val ME = FetchMonadError[Future]
 
   implicit override def executionContext = ExecutionContext.Implicits.global
 

--- a/shared/src/test/scala/TestHelper.scala
+++ b/shared/src/test/scala/TestHelper.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fetch
+
+import cats.data.NonEmptyList
+
+object TestHelper {
+
+  case class DidNotFound() extends Throwable
+
+  case class One(id: Int)
+  implicit object OneSource extends DataSource[One, Int] {
+    override def name = "OneSource"
+    override def fetchOne(id: One): Query[Option[Int]] =
+      Query.sync(Option(id.id))
+    override def fetchMany(ids: NonEmptyList[One]): Query[Map[One, Int]] =
+      Query.sync(ids.toList.map(one => (one, one.id)).toMap)
+  }
+  def one(id: Int): Fetch[Int] = Fetch(One(id))
+
+  case class AnotherOne(id: Int)
+  implicit object AnotheroneSource extends DataSource[AnotherOne, Int] {
+    override def name = "AnotherOneSource"
+    override def fetchOne(id: AnotherOne): Query[Option[Int]] =
+      Query.sync(Option(id.id))
+    override def fetchMany(ids: NonEmptyList[AnotherOne]): Query[Map[AnotherOne, Int]] =
+      Query.sync(ids.toList.map(anotherone => (anotherone, anotherone.id)).toMap)
+  }
+  def anotherOne(id: Int): Fetch[Int] = Fetch(AnotherOne(id))
+
+  case class Many(n: Int)
+  implicit object ManySource extends DataSource[Many, List[Int]] {
+    override def name = "ManySource"
+    override def fetchOne(id: Many): Query[Option[List[Int]]] =
+      Query.sync(Option(0 until id.n toList))
+    override def fetchMany(ids: NonEmptyList[Many]): Query[Map[Many, List[Int]]] =
+      Query.sync(ids.toList.map(m => (m, 0 until m.n toList)).toMap)
+  }
+  def many(id: Int): Fetch[List[Int]] = Fetch(Many(id))
+
+  case class Never()
+  implicit object NeverSource extends DataSource[Never, Int] {
+    override def name = "NeverSource"
+    override def fetchOne(id: Never): Query[Option[Int]] =
+      Query.sync(None)
+    override def fetchMany(ids: NonEmptyList[Never]): Query[Map[Never, Int]] =
+      Query.sync(Map.empty[Never, Int])
+  }
+
+  // Async DataSources
+
+  case class ArticleId(id: Int)
+  case class Article(id: Int, content: String) {
+    def author: Int = id + 1
+  }
+
+  implicit object ArticleAsync extends DataSource[ArticleId, Article] {
+    override def name = "ArticleAsync"
+    override def fetchOne(id: ArticleId): Query[Option[Article]] =
+      Query.async((ok, fail) => {
+        ok(Option(Article(id.id, "An article with id " + id.id)))
+      })
+    override def fetchMany(ids: NonEmptyList[ArticleId]): Query[Map[ArticleId, Article]] =
+      batchingNotSupported(ids)
+  }
+
+  def article(id: Int): Fetch[Article] = Fetch(ArticleId(id))
+
+  case class AuthorId(id: Int)
+  case class Author(id: Int, name: String)
+
+  implicit object AuthorAsync extends DataSource[AuthorId, Author] {
+    override def name = "AuthorAsync"
+    override def fetchOne(id: AuthorId): Query[Option[Author]] =
+      Query.async((ok, fail) => {
+        ok(Option(Author(id.id, "@egg" + id.id)))
+      })
+    override def fetchMany(ids: NonEmptyList[AuthorId]): Query[Map[AuthorId, Author]] =
+      batchingNotSupported(ids)
+  }
+
+  def author(a: Article): Fetch[Author] = Fetch(AuthorId(a.author))
+
+  // check Env
+
+  def requestFetches(r: FetchRequest): Int =
+    r match {
+      case FetchOne(_, _)       => 1
+      case FetchMany(ids, _)    => ids.toList.size
+      case Concurrent(requests) => requests.toList.map(requestFetches).sum
+    }
+
+  def totalFetched(rs: Seq[Round]): Int =
+    rs.map((round: Round) => requestFetches(round.request)).toList.sum
+
+  def requestBatches(r: FetchRequest): Int =
+    r match {
+      case FetchOne(_, _)    => 0
+      case FetchMany(ids, _) => 1
+      case Concurrent(requests) =>
+        requests.toList.count {
+          case FetchMany(_, _) => true
+          case _               => false
+        }
+    }
+
+  def totalBatches(rs: Seq[Round]): Int =
+    rs.map((round: Round) => requestBatches(round.request)).toList.sum
+}


### PR DESCRIPTION
I moved the "Async" `DataSource`s into `TestHelper`, moved `TestHelper` to its own file and reused `TestHelper` in the tests of `fetch-monix` and `fetch-twitter`.

I minimized the imports of the test files in the meanwhile.