### PR TITLE
Change delay in flacky timeout test

### DIFF
--- a/jvm/src/test/scala/FetchMonadErrorTimoutSpec.scala
+++ b/jvm/src/test/scala/FetchMonadErrorTimoutSpec.scala
@@ -37,7 +37,7 @@ trait FetchMonadErrorTimeoutSpec[F[_]] { self: AsyncFlatSpecLike with Matchers =
 
   "FetchMonadError" should "fail with timeout when a Query does not complete in time" in {
     recoverToSucceededIf[TimeoutException] {
-      runAsFuture { fetchMonadError.runQuery(delayQuery(100.millis, 300.millis)) }
+      runAsFuture { fetchMonadError.runQuery(delayQuery(100.millis, 600.millis)) }
     }
   }
 


### PR DESCRIPTION
Timeout test kept failing on Travis during release, increasing the delay should fix the problem.