### PR TITLE
Updated sbt-org-policies version to 0.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
 - 2.11.12
-- 2.12.4
+- 2.12.6
 
 jdk:
 - oraclejdk8

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -115,8 +115,8 @@ object ProjectPlugin extends AutoPlugin {
         ),
         orgUpdateDocFilesSetting += baseDirectory.value / "tut",
         scalaOrganization := "org.scala-lang",
-        scalaVersion := "2.12.4",
-        crossScalaVersions := List("2.11.12", "2.12.4"),
+        scalaVersion := "2.12.6",
+        crossScalaVersions := List("2.11.12", "2.12.6"),
         resolvers += Resolver.sonatypeRepo("snapshots"),
         scalacOptions := Seq(
           "-unchecked",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.22")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.1")


### PR DESCRIPTION
This PR updates the `sbt-org-policies` version to "0.9.1"