### PR TITLE
POC: Redesign without `IO`

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -18,7 +18,9 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val commonCrossDependencies: Seq[ModuleID] =
-      Seq("org.typelevel" %% "cats-effect" % "1.0.0",
+      Seq(
+        "io.chrisdavenport" %% "cats-par" % "0.2.0",
+        "org.typelevel" %% "cats-effect" % "1.0.0",
           %%("scalatest") % "test")
 
     lazy val micrositeSettings: Seq[Def.Setting[_]] = Seq(
@@ -109,6 +111,8 @@ object ProjectPlugin extends AutoPlugin {
         scalaVersion := "2.12.6",
         crossScalaVersions := List("2.11.12", "2.12.6"),
         resolvers += Resolver.sonatypeRepo("snapshots"),
+        resolvers += Resolver.sonatypeRepo("releases"),
+        addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
         scalacOptions := Seq(
           "-unchecked",
           "-deprecation",

--- a/shared/src/main/scala/cache.scala
+++ b/shared/src/main/scala/cache.scala
@@ -28,9 +28,9 @@ final class DataSourceResult(val result: Any) extends AnyVal
  * A `Cache` trait so the users of the library can provide their own cache.
  */
 trait DataSourceCache[F[_]] {
-  def lookup[I, A](i: I, ds: DataSource[F, I, A]): F[Option[A]]
-  def insert[I, A](i: I, v: A, ds: DataSource[F, I, A]): F[DataSourceCache[F]]
-  def insertMany[I, A](vs: Map[I, A], ds: DataSource[F, I, A])(implicit M: Monad[F]): F[DataSourceCache[F]] =
+  def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]]
+  def insert[I, A](i: I, v: A, ds: DataSource[I, A]): F[DataSourceCache[F]]
+  def insertMany[I, A](vs: Map[I, A], ds: DataSource[I, A])(implicit M: Monad[F]): F[DataSourceCache[F]] =
     vs.toList.foldLeftM(this)({
       case (c, (i, v)) => c.insert(i, v, ds)
     })
@@ -40,10 +40,10 @@ trait DataSourceCache[F[_]] {
  * A cache that stores its elements in memory.
  */
 case class InMemoryCache[F[_]: Applicative](state: Map[(DataSourceName, DataSourceId), DataSourceResult]) extends DataSourceCache[F] {
-  def lookup[I, A](i: I, ds: DataSource[F, I, A]): F[Option[A]] =
+  def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]] =
     Applicative[F].pure(state.get((new DataSourceName(ds.name), new DataSourceId(i))).map(_.result.asInstanceOf[A]))
 
-  def insert[I, A](i: I, v: A, ds: DataSource[F, I, A]): F[DataSourceCache[F]] =
+  def insert[I, A](i: I, v: A, ds: DataSource[I, A]): F[DataSourceCache[F]] =
     Applicative[F].pure(copy(state = state.updated((new DataSourceName(ds.name), new DataSourceId(i)), new DataSourceResult(v))))
 }
 

--- a/shared/src/main/scala/env.scala
+++ b/shared/src/main/scala/env.scala
@@ -22,16 +22,16 @@ import scala.collection.immutable._
  * An environment that is passed along during the fetch rounds. It holds the
  * cache and the list of rounds that have been executed.
  */
-trait Env[F[_]] {
-  def rounds: List[Round[F]]
-  def evolve(newRound: Round[F]): Env[F]
+trait Env {
+  def rounds: List[Round]
+  def evolve(newRound: Round): Env
 }
 
 /**
   * A data structure that holds information about a request inside a fetch round.
   */
-case class Request[F[_]](
-  request: FetchRequest[F],
+case class Request(
+  request: FetchRequest,
   start: Long,
   end: Long
 ) {
@@ -41,19 +41,19 @@ case class Request[F[_]](
 /**
  * A data structure that holds information about a fetch round.
  */
-case class Round[F[_]](
-  queries: List[Request[F]]
+case class Round(
+  queries: List[Request]
 )
 
 /**
  * A concrete implementation of `Env` used in the default Fetch interpreter.
  */
-case class FetchEnv[F[_]](
-    roundsQ: Queue[Round[F]] = Queue.empty
-) extends Env[F] {
+case class FetchEnv(
+    roundsQ: Queue[Round] = Queue.empty
+) extends Env {
   def rounds = roundsQ.toList
   def evolve(
-      newRound: Round[F]
-  ): FetchEnv[F] =
+      newRound: Round
+  ): Env =
     copy(roundsQ = roundsQ :+ newRound)
 }

--- a/shared/src/main/scala/env.scala
+++ b/shared/src/main/scala/env.scala
@@ -22,16 +22,16 @@ import scala.collection.immutable._
  * An environment that is passed along during the fetch rounds. It holds the
  * cache and the list of rounds that have been executed.
  */
-trait Env {
-  def rounds: List[Round]
-  def evolve(newRound: Round): Env
+trait Env[F[_]] {
+  def rounds: List[Round[F]]
+  def evolve(newRound: Round[F]): Env[F]
 }
 
 /**
   * A data structure that holds information about a request inside a fetch round.
   */
-case class Request(
-  request: FetchRequest,
+case class Request[F[_]](
+  request: FetchRequest[F],
   start: Long,
   end: Long
 ) {
@@ -41,19 +41,19 @@ case class Request(
 /**
  * A data structure that holds information about a fetch round.
  */
-case class Round(
-  queries: List[Request]
+case class Round[F[_]](
+  queries: List[Request[F]]
 )
 
 /**
  * A concrete implementation of `Env` used in the default Fetch interpreter.
  */
-case class FetchEnv(
-    roundsQ: Queue[Round] = Queue.empty
-) extends Env {
+case class FetchEnv[F[_]](
+    roundsQ: Queue[Round[F]] = Queue.empty
+) extends Env[F] {
   def rounds = roundsQ.toList
   def evolve(
-      newRound: Round
-  ): FetchEnv =
+      newRound: Round[F]
+  ): FetchEnv[F] =
     copy(roundsQ = roundsQ :+ newRound)
 }

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -22,27 +22,30 @@ import scala.util.control.NoStackTrace
 import scala.concurrent.duration.MILLISECONDS
 
 import cats._
-import cats.instances.list._
+//import cats.instances.list._
+import cats.data._
+import cats.implicits._
 import cats.effect._
 import cats.effect.concurrent.{Ref, Deferred}
-import cats.syntax.all._
-import cats.data.NonEmptyList
+import cats.temp.par._
+//import cats.syntax.all._
+//import cats.data.NonEmptyList
 
 
 object `package` {
   // Fetch queries
-  sealed trait FetchRequest extends Product with Serializable
+  sealed trait FetchRequest[F[_]] extends Product with Serializable
 
   // A query to a remote data source
-  sealed trait FetchQuery[I, A] extends FetchRequest {
+  sealed trait FetchQuery[F[_], I, A] extends FetchRequest[F] {
     def dataSource: DataSource[I, A]
     def identities: NonEmptyList[I]
   }
-  case class FetchOne[I, A](id: I, ds: DataSource[I, A]) extends FetchQuery[I, A] {
+  case class FetchOne[F[_], I, A](id: I, ds: DataSource[I, A]) extends FetchQuery[F, I, A] {
     override def identities: NonEmptyList[I] = NonEmptyList(id, List.empty[I])
     override def dataSource: DataSource[I, A] = ds
   }
-  case class Batch[I, A](ids: NonEmptyList[I], ds: DataSource[I, A]) extends FetchQuery[I, A] {
+  case class Batch[F[_], I, A](ids: NonEmptyList[I], ds: DataSource[I, A]) extends FetchQuery[F, I, A] {
     override def identities: NonEmptyList[I] = ids
     override def dataSource: DataSource[I, A] = ds
   }
@@ -53,24 +56,24 @@ object `package` {
   case class FetchMissing() extends FetchStatus
 
   // Fetch errors
-  sealed trait FetchException extends Throwable with NoStackTrace {
-    def environment: Env
+  sealed trait FetchException[F[_]] extends Throwable with NoStackTrace {
+    def environment: Env[F]
   }
-  case class MissingIdentity[I, A](i: I, request: FetchQuery[I, A], environment: Env) extends FetchException
-  case class UnhandledException(e: Throwable, environment: Env) extends FetchException
+  case class MissingIdentity[F[_], I, A](i: I, request: FetchQuery[F, I, A], environment: Env[F]) extends FetchException[F]
+  case class UnhandledException[F[_]](e: Throwable, environment: Env[F]) extends FetchException[F]
 
   // In-progress request
-  case class BlockedRequest(request: FetchRequest, result: FetchStatus => IO[Unit])
+  case class BlockedRequest[F[_]](request: FetchRequest[F], result: FetchStatus => F[Unit])
 
   /* Combines the identities of two `FetchQuery` to the same data source. */
-  private def combineIdentities[I, A](x: FetchQuery[I, A], y: FetchQuery[I, A]): NonEmptyList[I] = {
+  private def combineIdentities[F[_], I, A](x: FetchQuery[F, I, A], y: FetchQuery[F, I, A]): NonEmptyList[I] = {
     y.identities.foldLeft(x.identities) {
       case (acc, i) => if (acc.exists(_ == i)) acc else NonEmptyList(acc.head, acc.tail :+ i)
     }
   }
 
   /* Combines two requests to the same data source. */
-  private def combineRequests(x: BlockedRequest, y: BlockedRequest): BlockedRequest = (x.request, y.request) match {
+  private def combineRequests[F[_]](x: BlockedRequest[F], y: BlockedRequest[F]): BlockedRequest[F] = (x.request, y.request) match {
     case (a@FetchOne(aId, ds), b@FetchOne(anotherId, _)) =>
       if (aId == anotherId)  {
         val newRequest = FetchOne(aId, ds)
@@ -125,10 +128,10 @@ object `package` {
   }
 
   /* A map from datasources to blocked requests used to group requests to the same data source. */
-  case class RequestMap(m: Map[DataSource[Any, Any], BlockedRequest])
+  case class RequestMap[F[_]](m: Map[DataSource[F, Any, Any], BlockedRequest[F]])
 
   /* Combine two `RequestMap` instances to batch requests to the same data source. */
-  private def combineRequestMaps(x: RequestMap, y: RequestMap): RequestMap =
+  private def combineRequestMaps[F[_]](x: RequestMap[F], y: RequestMap[F]): RequestMap[F] =
     RequestMap(
       x.m.foldLeft(y.m) {
         case (acc, (ds, blocked)) => {
@@ -139,39 +142,39 @@ object `package` {
     )
 
   // `Fetch` result data type
-  sealed trait FetchResult[A]
-  case class Done[A](x: A) extends FetchResult[A]
-  case class Blocked[A](rs: RequestMap, cont: Fetch[A]) extends FetchResult[A]
-  case class Throw[A](e: Env => FetchException) extends FetchResult[A]
+  sealed trait FetchResult[F[_], A]
+  case class Done[F[_], A](x: A) extends FetchResult[F, A]
+  case class Blocked[F[_], A](rs: RequestMap[F], cont: Fetch[F, A]) extends FetchResult[F, A]
+  case class Throw[F[_], A](e: Env[F] => FetchException[F]) extends FetchResult[F, A]
 
   // Fetch data type
-  sealed trait Fetch[A] {
-    def run: IO[FetchResult[A]]
+  sealed trait Fetch[F[_], A] {
+    def run: F[FetchResult[F, A]]
   }
-  case class Unfetch[A](
-    run: IO[FetchResult[A]]
-  ) extends Fetch[A]
+  case class Unfetch[F[_], A](
+    run: F[FetchResult[F, A]]
+  ) extends Fetch[F, A]
 
   // Fetch ops
-  implicit val fetchM: Monad[Fetch] = new Monad[Fetch] {
-    def pure[A](a: A): Fetch[A] =
+  implicit def fetchM[F[_]: Monad]: Monad[Fetch[F, ?]] = new Monad[Fetch[F, ?]] {
+    def pure[A](a: A): Fetch[F, A] =
       Unfetch(
-        IO.pure(Done(a))
+        Monad[F].pure(Done(a))
       )
 
-    override def map[A, B](fa: Fetch[A])(f: A => B): Fetch[B] =
+    override def map[A, B](fa: Fetch[F, A])(f: A => B): Fetch[F, B] =
       Unfetch(for {
         fetch <- fa.run
         result = fetch match {
-          case Done(v) => Done(f(v))
+          case Done(v) => Done[F, B](f(v))
           case Blocked(br, cont) =>
             Blocked(br, map(cont)(f))
-          case Throw(e) => Throw[B](e)
+          case Throw(e) => Throw[F, B](e)
         }
       } yield result)
 
-    override def product[A, B](fa: Fetch[A], fb: Fetch[B]): Fetch[(A, B)] =
-      Unfetch(for {
+    override def product[A, B](fa: Fetch[F, A], fb: Fetch[F, B]): Fetch[F, (A, B)] =
+      Unfetch[F, (A, B)](for {
         fab <- (fa.run, fb.run).tupled
         result = fab match {
           case (Throw(e), _) =>
@@ -185,7 +188,7 @@ object `package` {
           case (Blocked(br, c), Blocked(br2, c2)) =>
             Blocked(combineRequestMaps(br, br2), product(c, c2))
           case (_, Throw(e)) =>
-            Throw[(A, B)](e)
+            Throw[F, (A, B)](e)
         }
       } yield result)
 
@@ -196,15 +199,15 @@ object `package` {
         case Right(b) => pure(b)
       })
 
-    def flatMap[A, B](fa: Fetch[A])(f: A => Fetch[B]): Fetch[B] =
+    def flatMap[A, B](fa: Fetch[F, A])(f: A => Fetch[F, B]): Fetch[F, B] =
       Unfetch(for {
         fetch <- fa.run
-        result: Fetch[B] = fetch match {
+        result: Fetch[F, B] = fetch match {
           case Done(v) => f(v)
-          case Throw(e) => Unfetch(IO.pure(Throw[B](e)))
-          case Blocked(br, cont : Fetch[A]) =>
-            Unfetch(
-              IO.pure(
+          case Throw(e) => Unfetch[F, B](Monad[F].pure(Throw[F, B](e)))
+          case Blocked(br, cont: Fetch[F, A]) =>
+            Unfetch[F, B](
+              Monad[F].pure(
                 Blocked(br, flatMap(cont)(f))
               )
             )
@@ -217,125 +220,125 @@ object `package` {
     /**
      * Lift a plain value to the Fetch monad.
      */
-    def pure[A](a: A): Fetch[A] =
-      Unfetch(IO.pure(Done(a)))
+    def pure[F[_]: Monad, A](a: A): Fetch[F, A] =
+      Unfetch(Monad[F].pure(Done(a)))
 
-    def exception[A](e: Env => FetchException): Fetch[A] =
-      Unfetch(IO.pure(Throw[A](e)))
+    def exception[F[_]: Monad, A](e: Env[F] => FetchException[F]): Fetch[F, A] =
+      Unfetch(Monad[F].pure(Throw[F, A](e)))
 
-    def error[A](e: Throwable): Fetch[A] =
+    def error[F[_]: Monad, A](e: Throwable): Fetch[F, A] =
       exception((env) => UnhandledException(e, env))
 
-    def apply[I, A](id: I, ds: DataSource[I, A])(
+    def apply[F[_]: Concurrent, I, A](id: I, ds: DataSource[F, I, A])(
       implicit
-        CS: ContextShift[IO]
-    ): Fetch[A] =
-      Unfetch(
+        CS: ContextShift[F]
+    ): Fetch[F, A] =
+      Unfetch[F, A](
         for {
-          deferred <- Deferred[IO, FetchStatus]
-          request = FetchOne[I, A](id, ds)
+          deferred <- Deferred[F, FetchStatus]
+          request = FetchOne(id, ds)
           result = deferred.complete _
           blocked = BlockedRequest(request, result)
-          anyDs = ds.asInstanceOf[DataSource[Any, Any]]
+          anyDs = ds.asInstanceOf[DataSource[F, Any, Any]]
           blockedRequest = RequestMap(Map(anyDs -> blocked))
-        } yield Blocked(blockedRequest, Unfetch(
-          deferred.get.flatMap(_ match {
+        } yield Blocked(blockedRequest, Unfetch[F, A](
+          deferred.get.flatMap {
             case FetchDone(a: A) =>
-              IO.pure(Done(a))
+              Monad[F].pure(Done(a))
             case FetchMissing() =>
-              IO.pure(Throw((env) => MissingIdentity[I, A](id, request, env)))
-          })
+              Monad[F].pure(Throw((env) => MissingIdentity(id, request, env)))
+          }
         ))
       )
 
     /**
       * Run a `Fetch`, the result in the `IO` monad.
       */
-    def run[A](
-      fa: Fetch[A],
-      cache: DataSourceCache = InMemoryCache.empty
+    def run[F[_]: Sync: Par, A](
+      fa: Fetch[F, A],
+      cache: DataSourceCache[F] = InMemoryCache.empty[F]
     )(
       implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[A] = for {
-      cache <- Ref.of[IO, DataSourceCache](cache)
+        CS: ContextShift[F],
+        T: Timer[F]
+    ): F[A] = for {
+      cache <- Ref.of[F, DataSourceCache[F]](cache)
       result <- performRun(fa, cache, None)
     } yield result
 
     /**
       * Run a `Fetch`, the environment and the result in the `IO` monad.
       */
-    def runEnv[A](
-      fa: Fetch[A],
-      cache: DataSourceCache = InMemoryCache.empty
+    def runEnv[F[_]: Sync: Par, A](
+      fa: Fetch[F, A],
+      cache: DataSourceCache[F] = InMemoryCache.empty[F]
     )(
       implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[(Env, A)] = for {
-      env <- Ref.of[IO, Env](FetchEnv())
-      cache <- Ref.of[IO, DataSourceCache](cache)
+        CS: ContextShift[F],
+        T: Timer[F]
+    ): F[(Env[F], A)] = for {
+      env <- Ref.of[F, Env[F]](FetchEnv())
+      cache <- Ref.of[F, DataSourceCache[F]](cache)
       result <- performRun(fa, cache, Some(env))
       e <- env.get
     } yield (e, result)
 
     /**
-      * Run a `Fetch`, the cache and the result in the `IO` monad.
+      * Run a `Fetch`, the cache and the result in the `F` monad.
       */
-    def runCache[A](
-      fa: Fetch[A],
-      cache: DataSourceCache = InMemoryCache.empty
+    def runCache[F[_]: Sync: Par, A](
+      fa: Fetch[F, A])(
+      cache: DataSourceCache[F]
     )(
       implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[(DataSourceCache, A)] = for {
-      cache <- Ref.of[IO, DataSourceCache](cache)
+        CS: ContextShift[F],
+        T: Timer[F]
+    ): F[(DataSourceCache[F], A)] = for {
+      cache <- Ref.of[F, DataSourceCache[F]](cache)
       result <- performRun(fa, cache, None)
       c <- cache.get
     } yield (c, result)
 
-    private def performRun[A](
-      fa: Fetch[A],
-      cache: Ref[IO, DataSourceCache],
-      env: Option[Ref[IO, Env]]
+    private def performRun[F[_]: Sync: Par, A](
+      fa: Fetch[F, A],
+      cache: Ref[F, DataSourceCache[F]],
+      env: Option[Ref[F, Env[F]]]
     )(
       implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[A] = for {
+        CS: ContextShift[F],
+        T: Timer[F]
+    ): F[A] = for {
       result <- fa.run
 
       value <- result match {
-        case Done(a) => Concurrent[IO].pure(a)
+        case Done(a) => Sync[F].pure(a)
         case Blocked(rs, cont) => for {
           _ <- fetchRound(rs, cache, env)
           result <- performRun(cont, cache, env)
         } yield result
         case Throw(envToThrowable) =>
-          env.fold(IO.pure(FetchEnv() : Env))(_.get).flatMap((e: Env) => IO.raiseError(envToThrowable(e)))
+          env.fold(Sync[F].pure(FetchEnv() : Env[F]))(_.get).flatMap((e: Env[F]) => Sync[F].raiseError(envToThrowable(e)))
       }
     } yield value
 
-    private def fetchRound[A](
-      rs: RequestMap,
-      cache: Ref[IO, DataSourceCache],
-      env: Option[Ref[IO, Env]]
+    private def fetchRound[F[_]: Sync: Par, A](
+      rs: RequestMap[F],
+      cache: Ref[F, DataSourceCache[F]],
+      env: Option[Ref[F, Env[F]]]
     )(
       implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[Unit] = {
+        CS: ContextShift[F],
+        T: Timer[F]
+    ): F[Unit] = {
       val blocked = rs.m.toList.map(_._2)
-      if (blocked.isEmpty) IO.unit
+      if (blocked.isEmpty) Sync[F].unit
       else
         for {
           requests <- NonEmptyList.fromListUnsafe(blocked).parTraverse(
             runBlockedRequest(_, cache, env)
           )
-          performedRequests = requests.foldLeft(List.empty[Request])(_ ++ _)
-          _ <- if (performedRequests.isEmpty) IO.unit
+          performedRequests = requests.foldLeft(List.empty[Request[F]])(_ ++ _)
+          _ <- if (performedRequests.isEmpty) Sync[F].unit
           else env match {
             case Some(e) => e.modify((oldE) => (oldE.evolve(Round(performedRequests)), oldE))
             case None => IO.unit
@@ -343,37 +346,37 @@ object `package` {
         } yield ()
     }
 
-    private def runBlockedRequest[A](
-      blocked: BlockedRequest,
-      cache: Ref[IO, DataSourceCache],
-      env: Option[Ref[IO, Env]]
+    private def runBlockedRequest[F[_]: Sync: Par, A](
+      blocked: BlockedRequest[F],
+      cache: Ref[F, DataSourceCache[F]],
+      env: Option[Ref[F, Env[F]]]
     )(
       implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[List[Request]] =
+        CS: ContextShift[F],
+        T: Timer[F]
+    ): F[List[Request[F]]] =
       blocked.request match {
-        case q @ FetchOne(id, ds) => runFetchOne(q, blocked.result, cache, env)
-        case q @ Batch(ids, ds) => runBatch(q, blocked.result, cache, env)
+        case q @ FetchOne(id, ds) => runFetchOne[F](q, blocked.result, cache, env)
+        case q @ Batch(ids, ds) => runBatch[F](q, blocked.result, cache, env)
       }
   }
 
-  private def runFetchOne(
-    q: FetchOne[Any, Any],
-    putResult: FetchStatus => IO[Unit],
-    cache: Ref[IO, DataSourceCache],
-    env: Option[Ref[IO, Env]]
+  private def runFetchOne[F[_]: Sync](
+    q: FetchOne[F, Any, Any],
+    putResult: FetchStatus => F[Unit],
+    cache: Ref[F, DataSourceCache[F]],
+    env: Option[Ref[F, Env[F]]]
   )(
     implicit
-      CS: ContextShift[IO],
-      T: Timer[IO]
-  ): IO[List[Request]] =
+      CS: ContextShift[F],
+      T: Timer[F]
+  ): F[List[Request[F]]] =
     for {
       c <- cache.get
       maybeCached <- c.lookup(q.id, q.ds)
       result <- maybeCached match {
         // Cached
-        case Some(v) => putResult(FetchDone(v)) >> IO.pure(Nil)
+        case Some(v) => putResult(FetchDone(v)) >> Sync[F].pure(Nil)
 
         // Not cached, must fetch
         case None => for {
@@ -390,32 +393,32 @@ object `package` {
 
             // Missing
             case None =>
-              putResult(FetchMissing()) >> IO.pure(List(Request(q, startTime, endTime)))
+              putResult(FetchMissing()) >> Sync[F].pure(List(Request(q, startTime, endTime)))
           }
         } yield result
       }
     } yield result
 
-  private case class BatchedRequest(
-    batches: List[Batch[Any, Any]],
+  private case class BatchedRequest[F[_]](
+    batches: List[Batch[F, Any, Any]],
     results: Map[Any, Any]
   )
 
-  private def runBatch(
-    q: Batch[Any, Any],
-    putResult: FetchStatus => IO[Unit],
-    cache: Ref[IO, DataSourceCache],
-    env: Option[Ref[IO, Env]]
+  private def runBatch[F[_]: Sync: Par](
+    q: Batch[F, Any, Any],
+    putResult: FetchStatus => F[Unit],
+    cache: Ref[F, DataSourceCache[F]],
+    env: Option[Ref[F, Env[F]]]
   )(
     implicit
-      CS: ContextShift[IO],
-      T: Timer[IO]
-  ): IO[List[Request]] =
+      CS: ContextShift[F],
+      T: Timer[F]
+  ): F[List[Request[F]]] =
     for {
       c <- cache.get
 
       // Remove cached IDs
-      idLookups <- q.ids.traverse[IO, (Any, Option[Any])](
+      idLookups <- q.ids.traverse[F, (Any, Option[Any])](
         (i) => c.lookup(i, q.ds).map( m => (i, m) )
       )
       cachedResults = idLookups.collect({
@@ -427,7 +430,7 @@ object `package` {
 
       result <- uncachedIds match {
         // All cached
-        case Nil => putResult(FetchDone[Map[Any, Any]](cachedResults)) >> IO.pure(Nil)
+        case Nil => putResult(FetchDone[Map[Any, Any]](cachedResults)) >> Sync[F].pure(Nil)
 
         // Some uncached
         case l@_ => for {
@@ -458,21 +461,21 @@ object `package` {
       }
     } yield result
 
-  private def runBatchedRequest(
-    q: Batch[Any, Any],
+  private def runBatchedRequest[F[_]: Monad: Par](
+    q: Batch[F, Any, Any],
     batchSize: Int,
     e: BatchExecution
   )(
     implicit
-      CS: ContextShift[IO],
-      T: Timer[IO]
-  ): IO[BatchedRequest] = {
+      CS: ContextShift[F],
+      T: Timer[F]
+  ): F[BatchedRequest[F]] = {
     val batches = NonEmptyList.fromListUnsafe(
       q.ids.toList.grouped(batchSize)
         .map(batchIds => NonEmptyList.fromListUnsafe(batchIds))
         .toList
     )
-    val reqs = batches.toList.map(Batch[Any, Any](_, q.ds))
+    val reqs = batches.toList.map(Batch[F, Any, Any](_, q.ds))
 
     val results = e match {
       case Sequentially =>

--- a/shared/src/main/scala/syntax.scala
+++ b/shared/src/main/scala/syntax.scala
@@ -20,43 +20,43 @@ import cats.effect._
 
 object syntax {
 
-  /** Implicit syntax to lift any value to the context of Fetch via pure */
-  implicit class FetchIdSyntax[A](val a: A) extends AnyVal {
+  // /** Implicit syntax to lift any value to the context of Fetch via pure */
+  // implicit class FetchIdSyntax[F[_], A](val a: A) extends AnyVal {
 
-    def fetch: Fetch[A] =
-      Fetch.pure(a)
-  }
+  //   def fetch: Fetch[F, A] =
+  //     Fetch.pure(a)
+  // }
 
 
-  /** Implicit syntax to lift exception to Fetch errors */
-  implicit class FetchExceptionSyntax(val a: Throwable) extends AnyVal {
+  // /** Implicit syntax to lift exception to Fetch errors */
+  // implicit class FetchExceptionSyntax[F[_]](val a: Throwable) extends AnyVal {
 
-    def fetch[B]: Fetch[B] =
-      Fetch.error[B](a)
-  }
+  //   def fetch[B]: Fetch[F, B] =
+  //     Fetch.error[F, B](a)
+  // }
 
-  /** Implicit syntax for Fetch ops */
-  implicit class FetchSyntax[A](val fa: Fetch[A]) extends AnyVal {
-    def runFetch(
-      implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[A] =
-      Fetch.run(fa)
+  // /** Implicit syntax for Fetch ops */
+  // implicit class FetchSyntax[F[_], A](val fa: Fetch[F, A]) extends AnyVal {
+  //   def runFetch(
+  //     implicit
+  //       CS: ContextShift[IO],
+  //       T: Timer[IO]
+  //   ): F[A] =
+  //     Fetch.run[F, A](fa)
 
-    def runEnv(
-      implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[(Env, A)] =
-      Fetch.runEnv(fa)
+  //   def runEnv[F[_]](
+  //     implicit
+  //       CS: ContextShift[IO],
+  //       T: Timer[IO]
+  //   ): F[(Env[F], A)] =
+  //     Fetch.runEnv[F, A](fa)
 
-    def runCache(
-      implicit
-        CS: ContextShift[IO],
-        T: Timer[IO]
-    ): IO[(DataSourceCache, A)] =
-      Fetch.runCache(fa)
-  }
+  //   def runCache[F[_]](
+  //     implicit
+  //       CS: ContextShift[IO],
+  //       T: Timer[IO]
+  //   ): F[(DataSourceCache, A)] =
+  //     Fetch.runCache[F, A](fa)
+  // }
 }
 

--- a/shared/src/test/scala/FetchAsyncQueryTests.scala
+++ b/shared/src/test/scala/FetchAsyncQueryTests.scala
@@ -34,56 +34,56 @@ class FetchAsyncQueryTests extends AsyncFreeSpec with Matchers {
 
   implicit def ioToFuture[A](io: IO[A]): Future[A] = io.unsafeToFuture()
 
-  "We can interpret an async fetch into an IO" in {
-    val fetch: Fetch[Article] = article(1)
-    val io: IO[Article]  = Fetch.run(fetch)
+  // "We can interpret an async fetch into an IO" in {
+  //   val fetch: Fetch[Article] = article(1)
+  //   val io: IO[Article]  = Fetch.run(fetch)
 
-    io.map(_ shouldEqual Article(1, "An article with id 1"))
-  }
+  //   io.map(_ shouldEqual Article(1, "An article with id 1"))
+  // }
 
-  "We can combine several async data sources and interpret a fetch into an IO" in {
-    val fetch: Fetch[(Article, Author)] = for {
-      art    <- article(1)
-      author <- author(art)
-    } yield (art, author)
+  // "We can combine several async data sources and interpret a fetch into an IO" in {
+  //   val fetch: Fetch[(Article, Author)] = for {
+  //     art    <- article(1)
+  //     author <- author(art)
+  //   } yield (art, author)
 
-    val io = Fetch.run(fetch)
+  //   val io = Fetch.run(fetch)
 
-    io.map(_ shouldEqual (Article(1, "An article with id 1"), Author(2, "@egg2")))
-  }
+  //   io.map(_ shouldEqual (Article(1, "An article with id 1"), Author(2, "@egg2")))
+  // }
 
-  "We can use combinators in a for comprehension and interpret a fetch from async sources into an IO" in {
-    val fetch: Fetch[List[Article]] = for {
-      articles <- List(1, 1, 2).traverse(article)
-    } yield articles
+  // "We can use combinators in a for comprehension and interpret a fetch from async sources into an IO" in {
+  //   val fetch: Fetch[List[Article]] = for {
+  //     articles <- List(1, 1, 2).traverse(article)
+  //   } yield articles
 
-    val io = Fetch.run(fetch)
-    io.map(_ shouldEqual List(
-      Article(1, "An article with id 1"),
-      Article(1, "An article with id 1"),
-      Article(2, "An article with id 2")
-    ))
-  }
+  //   val io = Fetch.run(fetch)
+  //   io.map(_ shouldEqual List(
+  //     Article(1, "An article with id 1"),
+  //     Article(1, "An article with id 1"),
+  //     Article(2, "An article with id 2")
+  //   ))
+  // }
 
-  "We can use combinators and multiple sources in a for comprehension and interpret a fetch from async sources into an IO" in {
-    val fetch = for {
-      articles <- List(1, 1, 2).traverse(article)
-      authors  <- articles.traverse(author)
-    } yield (articles, authors)
+  // "We can use combinators and multiple sources in a for comprehension and interpret a fetch from async sources into an IO" in {
+  //   val fetch = for {
+  //     articles <- List(1, 1, 2).traverse(article)
+  //     authors  <- articles.traverse(author)
+  //   } yield (articles, authors)
 
-    val io = Fetch.run(fetch)
+  //   val io = Fetch.run(fetch)
 
-    io.map(_ shouldEqual (
-      List(
-        Article(1, "An article with id 1"),
-        Article(1, "An article with id 1"),
-        Article(2, "An article with id 2")
-      ),
-      List(
-        Author(2, "@egg2"),
-        Author(2, "@egg2"),
-        Author(3, "@egg3")
-      )
-    ))
-  }
+  //   io.map(_ shouldEqual (
+  //     List(
+  //       Article(1, "An article with id 1"),
+  //       Article(1, "An article with id 1"),
+  //       Article(2, "An article with id 2")
+  //     ),
+  //     List(
+  //       Author(2, "@egg2"),
+  //       Author(2, "@egg2"),
+  //       Author(3, "@egg3")
+  //     )
+  //   ))
+  // }
 }

--- a/shared/src/test/scala/FetchBatchingTests.scala
+++ b/shared/src/test/scala/FetchBatchingTests.scala
@@ -37,129 +37,129 @@ class FetchBatchingTests extends AsyncFreeSpec with Matchers {
 
   implicit def ioToFuture[A](io: IO[A]): Future[A] = io.unsafeToFuture()
 
-  case class BatchedDataSeq(id: Int)
-  implicit object MaxBatchSourceSeq extends DataSource[BatchedDataSeq, Int] {
-    override def name = "BatchSourceSeq"
+  // case class BatchedDataSeq(id: Int)
+  // implicit object MaxBatchSourceSeq extends DataSource[BatchedDataSeq, Int] {
+  //   override def name = "BatchSourceSeq"
 
-    override def fetch(id: BatchedDataSeq): IO[Option[Int]] =
-      IO.pure(Some(id.id))
+  //   override def fetch(id: BatchedDataSeq): IO[Option[Int]] =
+  //     IO.pure(Some(id.id))
 
-    override val maxBatchSize = Some(2)
+  //   override val maxBatchSize = Some(2)
 
-    override val batchExecution = Sequentially
-  }
+  //   override val batchExecution = Sequentially
+  // }
 
-  case class BatchedDataPar(id: Int)
-  implicit object MaxBatchSourcePar extends DataSource[BatchedDataPar, Int] {
-    override def name = "BatchSourcePar"
+  // case class BatchedDataPar(id: Int)
+  // implicit object MaxBatchSourcePar extends DataSource[BatchedDataPar, Int] {
+  //   override def name = "BatchSourcePar"
 
-    override def fetch(id: BatchedDataPar): IO[Option[Int]] =
-      IO.pure(Some(id.id))
+  //   override def fetch(id: BatchedDataPar): IO[Option[Int]] =
+  //     IO.pure(Some(id.id))
 
-    override val maxBatchSize = Some(2)
+  //   override val maxBatchSize = Some(2)
 
-    override val batchExecution = InParallel
-  }
+  //   override val batchExecution = InParallel
+  // }
 
-  def fetchBatchedDataSeq(id: Int): Fetch[Int] = Fetch(BatchedDataSeq(id), MaxBatchSourceSeq)
-  def fetchBatchedDataPar(id: Int): Fetch[Int] = Fetch(BatchedDataPar(id), MaxBatchSourcePar)
+  // def fetchBatchedDataSeq(id: Int): Fetch[Int] = Fetch(BatchedDataSeq(id), MaxBatchSourceSeq)
+  // def fetchBatchedDataPar(id: Int): Fetch[Int] = Fetch(BatchedDataPar(id), MaxBatchSourcePar)
 
-  "A large fetch to a datasource with a maximum batch size is split and executed in sequence" in {
-    val fetch: Fetch[List[Int]] = List.range(1, 6).traverse(fetchBatchedDataSeq)
+  // "A large fetch to a datasource with a maximum batch size is split and executed in sequence" in {
+  //   val fetch: Fetch[List[Int]] = List.range(1, 6).traverse(fetchBatchedDataSeq)
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3, 4, 5)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 5
-        totalBatches(env.rounds) shouldEqual 3
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3, 4, 5)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 5
+  //       totalBatches(env.rounds) shouldEqual 3
+  //     }
+  //   })
+  // }
 
-  "A large fetch to a datasource with a maximum batch size is split and executed in parallel" in {
-    val fetch: Fetch[List[Int]] = List.range(1, 6).traverse(fetchBatchedDataPar)
+  // "A large fetch to a datasource with a maximum batch size is split and executed in parallel" in {
+  //   val fetch: Fetch[List[Int]] = List.range(1, 6).traverse(fetchBatchedDataPar)
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3, 4, 5)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 5
-        totalBatches(env.rounds) shouldEqual 3
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3, 4, 5)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 5
+  //       totalBatches(env.rounds) shouldEqual 3
+  //     }
+  //   })
+  // }
 
-  "Fetches to datasources with a maximum batch size should be split and executed in parallel and sequentially" in {
-    val fetch: Fetch[List[Int]] =
-      List.range(1, 6).traverse(fetchBatchedDataPar) *>
-        List.range(1, 6).traverse(fetchBatchedDataSeq)
+  // "Fetches to datasources with a maximum batch size should be split and executed in parallel and sequentially" in {
+  //   val fetch: Fetch[List[Int]] =
+  //     List.range(1, 6).traverse(fetchBatchedDataPar) *>
+  //       List.range(1, 6).traverse(fetchBatchedDataSeq)
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3, 4, 5)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 5 + 5
-        totalBatches(env.rounds) shouldEqual 3 + 3
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3, 4, 5)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 5 + 5
+  //       totalBatches(env.rounds) shouldEqual 3 + 3
+  //     }
+  //   })
+  // }
 
-  "A large (many) fetch to a datasource with a maximum batch size is split and executed in sequence" in {
-    val fetch: Fetch[List[Int]] =
-      List(fetchBatchedDataSeq(1), fetchBatchedDataSeq(2), fetchBatchedDataSeq(3)).sequence
+  // "A large (many) fetch to a datasource with a maximum batch size is split and executed in sequence" in {
+  //   val fetch: Fetch[List[Int]] =
+  //     List(fetchBatchedDataSeq(1), fetchBatchedDataSeq(2), fetchBatchedDataSeq(3)).sequence
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 3
-        totalBatches(env.rounds) shouldEqual 2
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 3
+  //       totalBatches(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
 
-  "A large (many) fetch to a datasource with a maximum batch size is split and executed in parallel" in {
-    val fetch: Fetch[List[Int]] =
-      List(fetchBatchedDataPar(1), fetchBatchedDataPar(2), fetchBatchedDataPar(3)).sequence
+  // "A large (many) fetch to a datasource with a maximum batch size is split and executed in parallel" in {
+  //   val fetch: Fetch[List[Int]] =
+  //     List(fetchBatchedDataPar(1), fetchBatchedDataPar(2), fetchBatchedDataPar(3)).sequence
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
 
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 3
-        totalBatches(env.rounds) shouldEqual 2
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 3
+  //       totalBatches(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
 
-  "Very deep fetches don't overflow stack or heap" in {
-    val depth = 200
-    val list  = (1 to depth).toList
-    val fetch: Fetch[List[Int]] = list
-      .map(x => (0 until x).toList.traverse(fetchBatchedDataSeq))
-      .foldLeft(
-        Fetch.pure(List.empty[Int])
-      )(_ >> _)
+  // "Very deep fetches don't overflow stack or heap" in {
+  //   val depth = 200
+  //   val list  = (1 to depth).toList
+  //   val fetch: Fetch[List[Int]] = list
+  //     .map(x => (0 until x).toList.traverse(fetchBatchedDataSeq))
+  //     .foldLeft(
+  //       Fetch.pure(List.empty[Int])
+  //     )(_ >> _)
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => {
-        result shouldEqual (0 until depth).toList
-        env.rounds.size shouldEqual depth
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (0 until depth).toList
+  //       env.rounds.size shouldEqual depth
+  //     }
+  //   })
+  // }
 }

--- a/shared/src/test/scala/FetchReportingTests.scala
+++ b/shared/src/test/scala/FetchReportingTests.scala
@@ -36,108 +36,108 @@ class FetchReportingTests extends AsyncFreeSpec with Matchers {
 
   implicit def ioToFuture[A](io: IO[A]): Future[A] = io.unsafeToFuture()
 
-  "Plain values have no rounds of execution" in {
-    val fetch: Fetch[Int] = Fetch.pure(42)
-    val io = Fetch.runEnv(fetch)
+  // "Plain values have no rounds of execution" in {
+  //   val fetch: Fetch[Int] = Fetch.pure(42)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 0
-    })
-  }
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 0
+  //   })
+  // }
 
-  "Single fetches are executed in one round" in {
-    val fetch = one(1)
-    val io = Fetch.runEnv(fetch)
+  // "Single fetches are executed in one round" in {
+  //   val fetch = one(1)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 1
-    })
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 1
+  //   })
 
-  }
+  // }
 
-  "Single fetches are executed in one round per binding in a for comprehension" in {
-    val fetch = for {
-      o <- one(1)
-      t <- one(2)
-    } yield (o, t)
-    val io = Fetch.runEnv(fetch)
+  // "Single fetches are executed in one round per binding in a for comprehension" in {
+  //   val fetch = for {
+  //     o <- one(1)
+  //     t <- one(2)
+  //   } yield (o, t)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 2
-    })
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 2
+  //   })
 
-  }
+  // }
 
-  "Single fetches for different data sources are executed in multiple rounds if they are in a for comprehension" in {
-    val fetch: Fetch[(Int, List[Int])] = for {
-      o <- one(1)
-      m <- many(3)
-    } yield (o, m)
+  // "Single fetches for different data sources are executed in multiple rounds if they are in a for comprehension" in {
+  //   val fetch: Fetch[(Int, List[Int])] = for {
+  //     o <- one(1)
+  //     m <- many(3)
+  //   } yield (o, m)
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 2
-    })
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 2
+  //   })
 
-  }
+  // }
 
-  "Single fetches combined with cartesian are run in one round" in {
-    val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
+  // "Single fetches combined with cartesian are run in one round" in {
+  //   val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 1
-    })
-  }
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 1
+  //   })
+  // }
 
-  "Single fetches combined with traverse are run in one round" in {
-    val fetch: Fetch[List[Int]] = for {
-      manies <- many(3)              // round 1
-      ones   <- manies.traverse(one) // round 2
-    } yield ones
+  // "Single fetches combined with traverse are run in one round" in {
+  //   val fetch: Fetch[List[Int]] = for {
+  //     manies <- many(3)              // round 1
+  //     ones   <- manies.traverse(one) // round 2
+  //   } yield ones
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 2
-    })
-  }
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 2
+  //   })
+  // }
 
-  "The product of two fetches from the same data source implies batching" in {
-    val fetch: Fetch[(Int, Int)] = (one(1), one(3)).tupled
+  // "The product of two fetches from the same data source implies batching" in {
+  //   val fetch: Fetch[(Int, Int)] = (one(1), one(3)).tupled
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 1
-    })
-  }
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 1
+  //   })
+  // }
 
-  "The product of concurrent fetches of the same type implies everything fetched in batches" in {
-    val aFetch = for {
-      a <- one(1)  // round 1
-      b <- one(2)  // round 2
-      c <- one(3)
-    } yield c
-    val anotherFetch = for {
-      a <- one(2)  // round 1
-      m <- many(4) // round 2
-      c <- one(3)
-    } yield c
-    val fetch = (
-      (
-        aFetch,
-        anotherFetch
-      ).tupled,
-      one(3)       // round 1
-    ).tupled
+  // "The product of concurrent fetches of the same type implies everything fetched in batches" in {
+  //   val aFetch = for {
+  //     a <- one(1)  // round 1
+  //     b <- one(2)  // round 2
+  //     c <- one(3)
+  //   } yield c
+  //   val anotherFetch = for {
+  //     a <- one(2)  // round 1
+  //     m <- many(4) // round 2
+  //     c <- one(3)
+  //   } yield c
+  //   val fetch = (
+  //     (
+  //       aFetch,
+  //       anotherFetch
+  //     ).tupled,
+  //     one(3)       // round 1
+  //   ).tupled
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => env.rounds.size shouldEqual 2
-    })
-  }
+  //   io.map({
+  //     case (env, result) => env.rounds.size shouldEqual 2
+  //   })
+  // }
 }

--- a/shared/src/test/scala/FetchSyntaxTests.scala
+++ b/shared/src/test/scala/FetchSyntaxTests.scala
@@ -36,68 +36,68 @@ class FetchSyntaxTests extends AsyncFreeSpec with Matchers {
 
   implicit def ioToFuture[A](io: IO[A]): Future[A] = io.unsafeToFuture()
 
-  "Cartesian syntax is implicitly concurrent" in {
-    val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
+  // "Cartesian syntax is implicitly concurrent" in {
+  //   val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) =>
-        env.rounds.size shouldEqual 1
-    })
-  }
+  //   io.map({
+  //     case (env, result) =>
+  //       env.rounds.size shouldEqual 1
+  //   })
+  // }
 
-  "Apply syntax is implicitly concurrent" in {
-    val fetch: Fetch[Int] = Fetch.pure((x: Int, y: Int) => x + y).ap2(one(1), one(2))
+  // "Apply syntax is implicitly concurrent" in {
+  //   val fetch: Fetch[Int] = Fetch.pure((x: Int, y: Int) => x + y).ap2(one(1), one(2))
 
-    val io = Fetch.runEnv(fetch)
+  //   val io = Fetch.runEnv(fetch)
 
-    io.map({
-      case (env, result) => {
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 2
-      }
-    })
-  }
+  //   io.map({
+  //     case (env, result) => {
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
 
-  "`fetch` syntax allows lifting of any value to the context of a fetch" in {
-    Fetch.pure(42) shouldEqual 42.fetch
-  }
+  // "`fetch` syntax allows lifting of any value to the context of a fetch" in {
+  //   Fetch.pure(42) shouldEqual 42.fetch
+  // }
 
-  "`fetch` syntax allows lifting of any `Throwable` as a failure on a fetch" in {
-    case object Ex extends RuntimeException
+  // "`fetch` syntax allows lifting of any `Throwable` as a failure on a fetch" in {
+  //   case object Ex extends RuntimeException
 
-    val f1: Fetch[Int] = Fetch.error(Ex)
-    val f2: Fetch[Int] = Ex.fetch
+  //   val f1: Fetch[Int] = Fetch.error(Ex)
+  //   val f2: Fetch[Int] = Ex.fetch
 
-    val io1 = Fetch.run(f1)
-    val io2 = Fetch.run(f2)
+  //   val io1 = Fetch.run(f1)
+  //   val io2 = Fetch.run(f2)
 
-    val e1 = io1.handleError(err => 42)
-    val e2 = io2.handleError(err => 42)
+  //   val e1 = io1.handleError(err => 42)
+  //   val e2 = io2.handleError(err => 42)
 
-    (e1, e2).mapN(_ shouldEqual _)
-  }
+  //   (e1, e2).mapN(_ shouldEqual _)
+  // }
 
-  "`runFetch` syntax is equivalent to `Fetch#run`" in {
-    val rf1 = Fetch.run(1.fetch)
-    val rf2 = 1.fetch.runFetch
+  // "`runFetch` syntax is equivalent to `Fetch#run`" in {
+  //   val rf1 = Fetch.run(1.fetch)
+  //   val rf2 = 1.fetch.runFetch
 
-    (rf1, rf2).mapN(_ shouldEqual _)
-  }
+  //   (rf1, rf2).mapN(_ shouldEqual _)
+  // }
 
-  "`runEnv` syntax is equivalent to `Fetch#runEnv`" in {
-    val rf1: IO[(Env, Int)] = Fetch.runEnv(1.fetch)
-    val rf2: IO[(Env, Int)] = 1.fetch.runEnv
+  // "`runEnv` syntax is equivalent to `Fetch#runEnv`" in {
+  //   val rf1: IO[(Env, Int)] = Fetch.runEnv(1.fetch)
+  //   val rf2: IO[(Env, Int)] = 1.fetch.runEnv
 
-    (rf1, rf2).mapN(_ shouldEqual _)
-  }
+  //   (rf1, rf2).mapN(_ shouldEqual _)
+  // }
 
-  "`runCache` syntax is equivalent to `Fetch#runCache`" in {
-    val rf1: IO[(DataSourceCache, Int)] = Fetch.runCache(1.fetch)
-    val rf2: IO[(DataSourceCache, Int)] = 1.fetch.runCache
+  // "`runCache` syntax is equivalent to `Fetch#runCache`" in {
+  //   val rf1: IO[(DataSourceCache, Int)] = Fetch.runCache(1.fetch)
+  //   val rf2: IO[(DataSourceCache, Int)] = 1.fetch.runCache
 
-    (rf1, rf2).mapN(_ shouldEqual _)
-  }
+  //   (rf1, rf2).mapN(_ shouldEqual _)
+  // }
 }

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -43,657 +43,668 @@ class FetchTests extends AsyncFreeSpec with Matchers {
   // Fetch ops
 
   "We can lift plain values to Fetch" in {
-    val fetch: Fetch[Int] = Fetch.pure(42)
-    Fetch.run(fetch).map(_ shouldEqual 42)
+    def fetch[F[_] : ConcurrentEffect]: Fetch[F, Int] =
+      Fetch.pure[F, Int](42)
+
+    Fetch.run[IO](fetch).map(_ shouldEqual 42)
   }
 
   "We can lift values which have a Data Source to Fetch" in {
-    Fetch.run(one(1)).map(_ shouldEqual 1)
+    Fetch.run[IO](one(1)).map(_ shouldEqual 1)
   }
 
   "We can map over Fetch values" in {
-    val fetch = one(1).map(_ + 1)
-    Fetch.run(fetch).map(_ shouldEqual 2)
+    def fetch[F[_] : ConcurrentEffect : ContextShift]: Fetch[F, (Int)] =
+      one(1).map(_ + 1)
+
+    Fetch.run[IO](fetch).map(_ shouldEqual 2)
   }
 
   "We can use fetch inside a for comprehension" in {
-    val fetch = for {
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, (Int, Int)] = for {
       o <- one(1)
       t <- one(2)
     } yield (o, t)
 
-    Fetch.run(fetch).map(_ shouldEqual (1, 2))
+    Fetch.run[IO](fetch).map(_ shouldEqual (1, 2))
   }
 
   "We can mix data sources" in {
-    val fetch: Fetch[(Int, List[Int])] = for {
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, (Int, List[Int])] = for {
       o <- one(1)
       m <- many(3)
     } yield (o, m)
 
-    Fetch.run(fetch).map(_ shouldEqual (1, List(0, 1, 2)))
+    Fetch.run[IO](fetch).map(_ shouldEqual (1, List(0, 1, 2)))
   }
 
   "We can use Fetch as a cartesian" in {
-    val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
-    val io                             = Fetch.run(fetch)
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, (Int, List[Int])] = (one(1), many(3)).tupled
+
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual (1, List(0, 1, 2)))
   }
 
   "We can use Fetch as an applicative" in {
-    val fetch: Fetch[Int] = (one(1), one(2), one(3)).mapN(_ + _ + _)
-    val io                = Fetch.run(fetch)
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, Int] = (one(1), one(2), one(3)).mapN(_ + _ + _)
+
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual 6)
   }
 
   "We can traverse over a list with a Fetch for each element" in {
-    val fetch: Fetch[List[Int]] = for {
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, List[Int]] = for {
       manies <- many(3)
-      ones   <- manies.traverse(one)
+      ones   <- manies.traverse(one[F])
     } yield ones
-    val io = Fetch.run(fetch)
+
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual List(0, 1, 2))
   }
 
   "We can depend on previous computations of Fetch values" in {
-    val fetch: Fetch[Int] = for {
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, Int] = for {
       o <- one(1)
       t <- one(o + 1)
     } yield o + t
 
-    val io = Fetch.run(fetch)
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual 3)
   }
 
   "We can collect a list of Fetch into one" in {
-    val sources: List[Fetch[Int]] = List(one(1), one(2), one(3))
-    val fetch: Fetch[List[Int]]   = sources.sequence
-    val io                        = Fetch.run(fetch)
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, List[Int]] =
+      List(one(1), one(2), one(3)).sequence
+
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual List(1, 2, 3))
   }
 
   "We can collect a list of Fetches with heterogeneous sources" in {
-    val sources: List[Fetch[Int]] = List(one(1), one(2), one(3), anotherOne(4), anotherOne(5))
-    val fetch: Fetch[List[Int]]   = sources.sequence
-    val io                        = Fetch.run(fetch)
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, List[Int]] =
+      List(one(1), one(2), one(3), anotherOne(4), anotherOne(5)).sequence
+
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual List(1, 2, 3, 4, 5))
   }
 
   "We can collect the results of a traversal" in {
-    val fetch = List(1, 2, 3).traverse(one)
-    val io    = Fetch.run(fetch)
+    def fetch[F[_] : ContextShift : ConcurrentEffect]: Fetch[F, List[Int]] =
+      List(1, 2, 3).traverse(one[F])
+
+    val io = Fetch.run[IO](fetch)
 
     io.map(_ shouldEqual List(1, 2, 3))
   }
 
   // Execution model
 
-  "Monadic bind implies sequential execution" in {
-    val fetch = for {
-      o <- one(1)
-      t <- one(2)
-    } yield (o, t)
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual (1, 2)
-        env.rounds.size shouldEqual 2
-      }
-    })
-  }
-
-  "Traversals are implicitly batched" in {
-    val fetch: Fetch[List[Int]] = for {
-      manies <- many(3)
-      ones   <- manies.traverse(one)
-    } yield ones
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(0, 1, 2)
-        env.rounds.size shouldEqual 2
-      }
-    })
-  }
-
-  "Sequencing is implicitly batched" in {
-    val fetch: Fetch[List[Int]] = List(one(1), one(2), one(3)).sequence
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 3
-        totalBatches(env.rounds) shouldEqual 1
-      }
-    })
-  }
-
-  "Identities are deduped when batched" in {
-    val manies = List(1, 1, 2)
-    val fetch: Fetch[List[Int]] = for {
-      ones <- manies.traverse(one)
-    } yield ones
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual manies
-        env.rounds.size shouldEqual 1
-        env.rounds.head.queries.size shouldEqual 1
-        env.rounds.head.queries.head.request should matchPattern {
-          case Batch(NonEmptyList(One(1), List(One(2))), _) =>
-        }
-      }
-    })
-  }
-
-  "The product of two fetches implies parallel fetching" in {
-    val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual (1, List(0, 1, 2))
-        env.rounds.size shouldEqual 1
-        env.rounds.head.queries.size shouldEqual 2
-      }
-    })
-  }
-
-  "Concurrent fetching calls batches only when it can" in {
-    val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual (1, List(0, 1, 2))
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 0
-      }
-    })
-  }
-
-  "Concurrent fetching performs requests to multiple data sources in parallel" in {
-    val fetch: Fetch[((Int, List[Int]), Int)] = ((one(1), many(2)).tupled, anotherOne(3)).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual ((1, List(0, 1)), 3)
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 0
-      }
-    })
-  }
-
-  "The product of concurrent fetches implies everything fetched concurrently" in {
-    val fetch = (
-      (
-        one(1),
-        (one(2), one(3)).tupled
-      ).tupled,
-      one(4)
-    ).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual ((1, (2, 3)), 4)
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 4
-      }
-    })
-  }
-
-  "The product of concurrent fetches of the same type implies everything fetched in a single batch" in {
-    val aFetch = for {
-      a <- one(1)  // round 1
-      b <- many(1) // round 2
-      c <- one(1)
-    } yield c
-    val anotherFetch = for {
-      a <- one(2)  // round 1
-      m <- many(2) // round 2
-      c <- one(2)
-    } yield c
-
-    val fetch = (
-      (aFetch, anotherFetch).tupled,
-      one(3)       // round 1
-    ).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual ((1, 2), 3)
-        env.rounds.size shouldEqual 2
-        totalBatches(env.rounds) shouldEqual 2
-        totalFetched(env.rounds) shouldEqual 5
-      }
-    })
-  }
-
-  "Every level of joined concurrent fetches is combined and batched" in {
-    val aFetch = for {
-      a <- one(1)  // round 1
-      b <- many(1) // round 2
-      c <- one(1)
-    } yield c
-    val anotherFetch = for {
-      a <- one(2)  // round 1
-      m <- many(2) // round 2
-      c <- one(2)
-    } yield c
-
-    val fetch = (aFetch, anotherFetch).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual (1, 2)
-        env.rounds.size shouldEqual 2
-        totalBatches(env.rounds) shouldEqual 2
-        totalFetched(env.rounds) shouldEqual 4
-      }
-    })
-  }
-
-  "Every level of sequenced concurrent fetches is batched" in {
-    val aFetch =
-      for {
-        a <- List(2, 3, 4).traverse(one)   // round 1
-        b <- List(0, 1).traverse(many)     // round 2
-        c <- List(9, 10, 11).traverse(one) // round 3
-      } yield c
-
-    val anotherFetch =
-      for {
-        a <- List(5, 6, 7).traverse(one)    // round 1
-        b <- List(2, 3).traverse(many)      // round 2
-        c <- List(12, 13, 14).traverse(one) // round 3
-      } yield c
-
-    val fetch = (
-       (aFetch, anotherFetch).tupled,
-       List(15, 16, 17).traverse(one)      // round 1
-    ).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual ((List(9, 10, 11), List(12, 13, 14)), List(15, 16, 17))
-        env.rounds.size shouldEqual 3
-        totalBatches(env.rounds) shouldEqual 3
-        totalFetched(env.rounds) shouldEqual 9 + 4 + 6
-      }
-    })
-  }
-
-  "The product of two fetches from the same data source implies batching" in {
-    val fetch: Fetch[(Int, Int)] = (one(1), one(3)).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual (1, 3)
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 2
-      }
-    })
-  }
-
-  "Sequenced fetches are run concurrently" in {
-    val sources: List[Fetch[Int]] = List(one(1), one(2), one(3), anotherOne(4), anotherOne(5))
-    val fetch: Fetch[List[Int]]   = sources.sequence
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3, 4, 5)
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 2
-      }
-    })
-  }
-
-  "Sequenced fetches are deduped" in {
-    val sources: List[Fetch[Int]] = List(one(1), one(2), one(1))
-    val fetch: Fetch[List[Int]]   = sources.sequence
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 1)
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 2
-      }
-    })
-  }
-
-  "Traversals are batched" in {
-    val fetch = List(1, 2, 3).traverse(one)
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 3)
-        env.rounds.size shouldEqual 1
-        totalBatches(env.rounds) shouldEqual 1
-      }
-    })
-  }
-
-  "Duplicated sources are only fetched once" in {
-    val fetch = List(1, 2, 1).traverse(one)
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 1)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 2
-      }
-    })
-  }
-
-  "Sources that can be fetched concurrently inside a for comprehension will be" in {
-    val fetch = for {
-      v      <- Fetch.pure(List(1, 2, 1))
-      result <- v.traverse(one)
-    } yield result
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual List(1, 2, 1)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 2
-      }
-    })
-  }
-
-  "Pure Fetches allow to explore further in the Fetch" in {
-    val aFetch = for {
-      a <- Fetch.pure(2)
-      b <- one(3)
-    } yield a + b
-
-    val fetch: Fetch[(Int, Int)] = (one(1), aFetch).tupled
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual (1, 5)
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 2
-      }
-    })
-  }
-
-  // Caching
-
-  "Elements are cached and thus not fetched more than once" in {
-    val fetch = for {
-      aOne       <- one(1)
-      anotherOne <- one(1)
-      _          <- one(1)
-      _          <- one(2)
-      _          <- one(3)
-      _          <- one(1)
-      _          <- List(1, 2, 3).traverse(one)
-      _          <- one(1)
-    } yield aOne + anotherOne
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual 2
-        totalFetched(env.rounds) shouldEqual 3
-      }
-    })
-  }
-
-  "Batched elements are cached and thus not fetched more than once" in {
-    val fetch = for {
-      _          <- List(1, 2, 3).traverse(one)
-      aOne       <- one(1)
-      anotherOne <- one(1)
-      _          <- one(1)
-      _          <- one(2)
-      _          <- one(3)
-      _          <- one(1)
-      _          <- one(1)
-    } yield aOne + anotherOne
-
-    val io = Fetch.runEnv(fetch)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual 2
-        env.rounds.size shouldEqual 1
-        totalFetched(env.rounds) shouldEqual 3
-      }
-    })
-  }
-
-  "Elements that are cached won't be fetched" in {
-    val fetch = for {
-      aOne       <- one(1)
-      anotherOne <- one(1)
-      _          <- one(1)
-      _          <- one(2)
-      _          <- one(3)
-      _          <- one(1)
-      _          <- List(1, 2, 3).traverse(one)
-      _          <- one(1)
-    } yield aOne + anotherOne
-
-    val cache = InMemoryCache.from(
-      (OneSource.name, One(1)) -> 1,
-      (OneSource.name, One(2)) -> 2,
-      (OneSource.name, One(3)) -> 3
-    )
-
-    val io = Fetch.runEnv(fetch, cache)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual 2
-        totalFetched(env.rounds) shouldEqual 0
-        env.rounds.size shouldEqual 0
-      }
-    })
-  }
-
-  case class ForgetfulCache() extends DataSourceCache {
-    def insert[I, A](i: I, v: A, ds: DataSource[I, A]): IO[ForgetfulCache] = IO.pure(this)
-    def lookup[I, A](i: I, ds: DataSource[I, A]): IO[Option[A]] = IO.pure(None)
-  }
-
-  "We can use a custom cache that discards elements" in {
-    val fetch = for {
-      aOne       <- one(1)
-      anotherOne <- one(1)
-      _          <- one(1)
-      _          <- one(2)
-      _          <- one(3)
-      _          <- one(1)
-      _          <- one(1)
-    } yield aOne + anotherOne
-
-    val cache = ForgetfulCache()
-    val io = Fetch.runEnv(fetch, cache)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual 2
-        env.rounds.size shouldEqual 7
-        totalFetched(env.rounds) shouldEqual 7
-      }
-    })
-  }
-
-  "We can use a custom cache that discards elements together with concurrent fetches" in {
-    val fetch = for {
-      aOne       <- one(1)
-      anotherOne <- one(1)
-      _          <- one(1)
-      _          <- one(2)
-      _          <- List(1, 2, 3).traverse(one)
-      _          <- one(3)
-      _          <- one(1)
-      _          <- one(1)
-    } yield aOne + anotherOne
-
-    val cache = ForgetfulCache()
-    val io = Fetch.runEnv(fetch, cache)
-
-    io.map({
-      case (env, result) => {
-        result shouldEqual 2
-        env.rounds.size shouldEqual 8
-        totalFetched(env.rounds) shouldEqual 10
-      }
-    })
-  }
-
-  // Errors
-
-  "Data sources with errors throw fetch failures" in {
-    val fetch: Fetch[Int] = never
-    val io                = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(MissingIdentity(Never(), _, _)) =>
-      })
-  }
-
-  "Data sources with errors throw fetch failures that can be handled" in {
-    val fetch: Fetch[Int] = never
-    val io                = Fetch.run(fetch)
-
-    io.handleErrorWith(err => IO.pure(42))
-      .map(_ shouldEqual 42)
-  }
-
-  "Data sources with errors won't fail if they're cached" in {
-    val fetch: Fetch[Int] = never
-
-    val cache = InMemoryCache.from(
-      (NeverSource.name, Never()) -> 1
-    )
-    val io = Fetch.run(fetch, cache)
-
-    io.map(_ shouldEqual 1)
-  }
-
-  "We can lift errors to Fetch" in {
-    val fetch: Fetch[Int] = Fetch.error(AnException())
-
-    val io = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(UnhandledException(AnException(), _)) =>
-      })
-  }
-
-  "We can lift handle and recover from errors in Fetch" in {
-    val fetch: Fetch[Int] = Fetch.error(AnException())
-
-    val io = Fetch.run(fetch)
-
-    io.handleErrorWith(err => IO.pure(42))
-      .map(_ shouldEqual 42)
-  }
-
-  "If a fetch fails in the left hand of a product the product will fail" in {
-    val error: Fetch[Int] = Fetch.error(AnException())
-    val fetch: Fetch[(Int, List[Int])] = (error, many(3)).tupled
-
-    val io = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(UnhandledException(AnException(), _)) =>
-      })
-  }
-
-  "If a fetch fails in the right hand of a product the product will fail" in {
-    val error: Fetch[Int] = Fetch.error(AnException())
-    val fetch: Fetch[(List[Int], Int)] = (many(3), error).tupled
-
-    val io = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(UnhandledException(AnException(), _)) =>
-      })
-  }
-
-  "If there is a missing identity in the left hand of a product the product will fail" in {
-    val fetch: Fetch[(Int, List[Int])] = (never,  many(3)).tupled
-
-    val io = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(MissingIdentity(Never(), _, _)) =>
-      })
-  }
-
-  "If there is a missing identity in the right hand of a product the product will fail" in {
-    val fetch: Fetch[(List[Int], Int)] = (many(3),  never).tupled
-
-    val io = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(MissingIdentity(Never(), _, _)) =>
-      })
-  }
-
-  "If there are multiple failing identities the fetch will fail" in {
-    val fetch: Fetch[(Int, Int)] = (never,  never).tupled
-
-    val io = Fetch.run(fetch)
-
-    io.attempt
-      .map(_ should matchPattern {
-        case Left(MissingIdentity(Never(), _, _)) =>
-      })
-  }
+  // "Monadic bind implies sequential execution" in {
+  //   val fetch = for {
+  //     o <- one(1)
+  //     t <- one(2)
+  //   } yield (o, t)
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (1, 2)
+  //       env.rounds.size shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Traversals are implicitly batched" in {
+  //   val fetch: Fetch[List[Int]] = for {
+  //     manies <- many(3)
+  //     ones   <- manies.traverse(one)
+  //   } yield ones
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(0, 1, 2)
+  //       env.rounds.size shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Sequencing is implicitly batched" in {
+  //   val fetch: Fetch[List[Int]] = List(one(1), one(2), one(3)).sequence
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 3
+  //       totalBatches(env.rounds) shouldEqual 1
+  //     }
+  //   })
+  // }
+
+  // "Identities are deduped when batched" in {
+  //   val manies = List(1, 1, 2)
+  //   val fetch: Fetch[List[Int]] = for {
+  //     ones <- manies.traverse(one)
+  //   } yield ones
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual manies
+  //       env.rounds.size shouldEqual 1
+  //       env.rounds.head.queries.size shouldEqual 1
+  //       env.rounds.head.queries.head.request should matchPattern {
+  //         case Batch(NonEmptyList(One(1), List(One(2))), _) =>
+  //       }
+  //     }
+  //   })
+  // }
+
+  // "The product of two fetches implies parallel fetching" in {
+  //   val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (1, List(0, 1, 2))
+  //       env.rounds.size shouldEqual 1
+  //       env.rounds.head.queries.size shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Concurrent fetching calls batches only when it can" in {
+  //   val fetch: Fetch[(Int, List[Int])] = (one(1), many(3)).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (1, List(0, 1, 2))
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 0
+  //     }
+  //   })
+  // }
+
+  // "Concurrent fetching performs requests to multiple data sources in parallel" in {
+  //   val fetch: Fetch[((Int, List[Int]), Int)] = ((one(1), many(2)).tupled, anotherOne(3)).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual ((1, List(0, 1)), 3)
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 0
+  //     }
+  //   })
+  // }
+
+  // "The product of concurrent fetches implies everything fetched concurrently" in {
+  //   val fetch = (
+  //     (
+  //       one(1),
+  //       (one(2), one(3)).tupled
+  //     ).tupled,
+  //     one(4)
+  //   ).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual ((1, (2, 3)), 4)
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 4
+  //     }
+  //   })
+  // }
+
+  // "The product of concurrent fetches of the same type implies everything fetched in a single batch" in {
+  //   val aFetch = for {
+  //     a <- one(1)  // round 1
+  //     b <- many(1) // round 2
+  //     c <- one(1)
+  //   } yield c
+  //   val anotherFetch = for {
+  //     a <- one(2)  // round 1
+  //     m <- many(2) // round 2
+  //     c <- one(2)
+  //   } yield c
+
+  //   val fetch = (
+  //     (aFetch, anotherFetch).tupled,
+  //     one(3)       // round 1
+  //   ).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual ((1, 2), 3)
+  //       env.rounds.size shouldEqual 2
+  //       totalBatches(env.rounds) shouldEqual 2
+  //       totalFetched(env.rounds) shouldEqual 5
+  //     }
+  //   })
+  // }
+
+  // "Every level of joined concurrent fetches is combined and batched" in {
+  //   val aFetch = for {
+  //     a <- one(1)  // round 1
+  //     b <- many(1) // round 2
+  //     c <- one(1)
+  //   } yield c
+  //   val anotherFetch = for {
+  //     a <- one(2)  // round 1
+  //     m <- many(2) // round 2
+  //     c <- one(2)
+  //   } yield c
+
+  //   val fetch = (aFetch, anotherFetch).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (1, 2)
+  //       env.rounds.size shouldEqual 2
+  //       totalBatches(env.rounds) shouldEqual 2
+  //       totalFetched(env.rounds) shouldEqual 4
+  //     }
+  //   })
+  // }
+
+  // "Every level of sequenced concurrent fetches is batched" in {
+  //   val aFetch =
+  //     for {
+  //       a <- List(2, 3, 4).traverse(one)   // round 1
+  //       b <- List(0, 1).traverse(many)     // round 2
+  //       c <- List(9, 10, 11).traverse(one) // round 3
+  //     } yield c
+
+  //   val anotherFetch =
+  //     for {
+  //       a <- List(5, 6, 7).traverse(one)    // round 1
+  //       b <- List(2, 3).traverse(many)      // round 2
+  //       c <- List(12, 13, 14).traverse(one) // round 3
+  //     } yield c
+
+  //   val fetch = (
+  //      (aFetch, anotherFetch).tupled,
+  //      List(15, 16, 17).traverse(one)      // round 1
+  //   ).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual ((List(9, 10, 11), List(12, 13, 14)), List(15, 16, 17))
+  //       env.rounds.size shouldEqual 3
+  //       totalBatches(env.rounds) shouldEqual 3
+  //       totalFetched(env.rounds) shouldEqual 9 + 4 + 6
+  //     }
+  //   })
+  // }
+
+  // "The product of two fetches from the same data source implies batching" in {
+  //   val fetch: Fetch[(Int, Int)] = (one(1), one(3)).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (1, 3)
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Sequenced fetches are run concurrently" in {
+  //   val sources: List[Fetch[Int]] = List(one(1), one(2), one(3), anotherOne(4), anotherOne(5))
+  //   val fetch: Fetch[List[Int]]   = sources.sequence
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3, 4, 5)
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Sequenced fetches are deduped" in {
+  //   val sources: List[Fetch[Int]] = List(one(1), one(2), one(1))
+  //   val fetch: Fetch[List[Int]]   = sources.sequence
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 1)
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Traversals are batched" in {
+  //   val fetch = List(1, 2, 3).traverse(one)
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 3)
+  //       env.rounds.size shouldEqual 1
+  //       totalBatches(env.rounds) shouldEqual 1
+  //     }
+  //   })
+  // }
+
+  // "Duplicated sources are only fetched once" in {
+  //   val fetch = List(1, 2, 1).traverse(one)
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 1)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Sources that can be fetched concurrently inside a for comprehension will be" in {
+  //   val fetch = for {
+  //     v      <- Fetch.pure(List(1, 2, 1))
+  //     result <- v.traverse(one)
+  //   } yield result
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual List(1, 2, 1)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // "Pure Fetches allow to explore further in the Fetch" in {
+  //   val aFetch = for {
+  //     a <- Fetch.pure(2)
+  //     b <- one(3)
+  //   } yield a + b
+
+  //   val fetch: Fetch[(Int, Int)] = (one(1), aFetch).tupled
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual (1, 5)
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 2
+  //     }
+  //   })
+  // }
+
+  // // Caching
+
+  // "Elements are cached and thus not fetched more than once" in {
+  //   val fetch = for {
+  //     aOne       <- one(1)
+  //     anotherOne <- one(1)
+  //     _          <- one(1)
+  //     _          <- one(2)
+  //     _          <- one(3)
+  //     _          <- one(1)
+  //     _          <- List(1, 2, 3).traverse(one)
+  //     _          <- one(1)
+  //   } yield aOne + anotherOne
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual 2
+  //       totalFetched(env.rounds) shouldEqual 3
+  //     }
+  //   })
+  // }
+
+  // "Batched elements are cached and thus not fetched more than once" in {
+  //   val fetch = for {
+  //     _          <- List(1, 2, 3).traverse(one)
+  //     aOne       <- one(1)
+  //     anotherOne <- one(1)
+  //     _          <- one(1)
+  //     _          <- one(2)
+  //     _          <- one(3)
+  //     _          <- one(1)
+  //     _          <- one(1)
+  //   } yield aOne + anotherOne
+
+  //   val io = Fetch.runEnv(fetch)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual 2
+  //       env.rounds.size shouldEqual 1
+  //       totalFetched(env.rounds) shouldEqual 3
+  //     }
+  //   })
+  // }
+
+  // "Elements that are cached won't be fetched" in {
+  //   val fetch = for {
+  //     aOne       <- one(1)
+  //     anotherOne <- one(1)
+  //     _          <- one(1)
+  //     _          <- one(2)
+  //     _          <- one(3)
+  //     _          <- one(1)
+  //     _          <- List(1, 2, 3).traverse(one)
+  //     _          <- one(1)
+  //   } yield aOne + anotherOne
+
+  //   val cache = InMemoryCache.from(
+  //     (OneSource.name, One(1)) -> 1,
+  //     (OneSource.name, One(2)) -> 2,
+  //     (OneSource.name, One(3)) -> 3
+  //   )
+
+  //   val io = Fetch.runEnv(fetch, cache)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual 2
+  //       totalFetched(env.rounds) shouldEqual 0
+  //       env.rounds.size shouldEqual 0
+  //     }
+  //   })
+  // }
+
+  // case class ForgetfulCache() extends DataSourceCache {
+  //   def insert[I, A](i: I, v: A, ds: DataSource[I, A]): IO[ForgetfulCache] = IO.pure(this)
+  //   def lookup[I, A](i: I, ds: DataSource[I, A]): IO[Option[A]] = IO.pure(None)
+  // }
+
+  // "We can use a custom cache that discards elements" in {
+  //   val fetch = for {
+  //     aOne       <- one(1)
+  //     anotherOne <- one(1)
+  //     _          <- one(1)
+  //     _          <- one(2)
+  //     _          <- one(3)
+  //     _          <- one(1)
+  //     _          <- one(1)
+  //   } yield aOne + anotherOne
+
+  //   val cache = ForgetfulCache()
+  //   val io = Fetch.runEnv(fetch, cache)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual 2
+  //       env.rounds.size shouldEqual 7
+  //       totalFetched(env.rounds) shouldEqual 7
+  //     }
+  //   })
+  // }
+
+  // "We can use a custom cache that discards elements together with concurrent fetches" in {
+  //   val fetch = for {
+  //     aOne       <- one(1)
+  //     anotherOne <- one(1)
+  //     _          <- one(1)
+  //     _          <- one(2)
+  //     _          <- List(1, 2, 3).traverse(one)
+  //     _          <- one(3)
+  //     _          <- one(1)
+  //     _          <- one(1)
+  //   } yield aOne + anotherOne
+
+  //   val cache = ForgetfulCache()
+  //   val io = Fetch.runEnv(fetch, cache)
+
+  //   io.map({
+  //     case (env, result) => {
+  //       result shouldEqual 2
+  //       env.rounds.size shouldEqual 8
+  //       totalFetched(env.rounds) shouldEqual 10
+  //     }
+  //   })
+  // }
+
+  // // Errors
+
+  // "Data sources with errors throw fetch failures" in {
+  //   val fetch: Fetch[Int] = never
+  //   val io                = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(MissingIdentity(Never(), _, _)) =>
+  //     })
+  // }
+
+  // "Data sources with errors throw fetch failures that can be handled" in {
+  //   val fetch: Fetch[Int] = never
+  //   val io                = Fetch.run(fetch)
+
+  //   io.handleErrorWith(err => IO.pure(42))
+  //     .map(_ shouldEqual 42)
+  // }
+
+  // "Data sources with errors won't fail if they're cached" in {
+  //   val fetch: Fetch[Int] = never
+
+  //   val cache = InMemoryCache.from(
+  //     (NeverSource.name, Never()) -> 1
+  //   )
+  //   val io = Fetch.run(fetch, cache)
+
+  //   io.map(_ shouldEqual 1)
+  // }
+
+  // "We can lift errors to Fetch" in {
+  //   val fetch: Fetch[Int] = Fetch.error(AnException())
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(UnhandledException(AnException(), _)) =>
+  //     })
+  // }
+
+  // "We can lift handle and recover from errors in Fetch" in {
+  //   val fetch: Fetch[Int] = Fetch.error(AnException())
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.handleErrorWith(err => IO.pure(42))
+  //     .map(_ shouldEqual 42)
+  // }
+
+  // "If a fetch fails in the left hand of a product the product will fail" in {
+  //   val error: Fetch[Int] = Fetch.error(AnException())
+  //   val fetch: Fetch[(Int, List[Int])] = (error, many(3)).tupled
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(UnhandledException(AnException(), _)) =>
+  //     })
+  // }
+
+  // "If a fetch fails in the right hand of a product the product will fail" in {
+  //   val error: Fetch[Int] = Fetch.error(AnException())
+  //   val fetch: Fetch[(List[Int], Int)] = (many(3), error).tupled
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(UnhandledException(AnException(), _)) =>
+  //     })
+  // }
+
+  // "If there is a missing identity in the left hand of a product the product will fail" in {
+  //   val fetch: Fetch[(Int, List[Int])] = (never,  many(3)).tupled
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(MissingIdentity(Never(), _, _)) =>
+  //     })
+  // }
+
+  // "If there is a missing identity in the right hand of a product the product will fail" in {
+  //   val fetch: Fetch[(List[Int], Int)] = (many(3),  never).tupled
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(MissingIdentity(Never(), _, _)) =>
+  //     })
+  // }
+
+  // "If there are multiple failing identities the fetch will fail" in {
+  //   val fetch: Fetch[(Int, Int)] = (never,  never).tupled
+
+  //   val io = Fetch.run(fetch)
+
+  //   io.attempt
+  //     .map(_ should matchPattern {
+  //       case Left(MissingIdentity(Never(), _, _)) =>
+  //     })
+  // }
 }


### PR DESCRIPTION
I experimented with changing #155 to not require `IO`. The stated reasons for specifying `IO` were for `Ref` and `Deferred`, but those only require `Sync` and `Concurrent` respectively. I wanted to see if we could remove the requirement for IO, allowing Monix or other implementations to be used.

This is just a proof of concept. I didn't update the tests or anything, it also adds a `F[_]` parameter all over the place. This can probably be wrapped up in an abstract class or something to simplify the API. I just wanted to see if it would work. 