### PR TITLE
Introduce Fetch#optional for performing optional fetches

### DIFF
--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -241,6 +241,25 @@ object `package` {
         ))
       )
 
+    def optional[F[_] : ConcurrentEffect, I, A](id: I, ds: DataSource[I, A]): Fetch[F, Option[A]] =
+      Unfetch[F, Option[A]](
+        for {
+          deferred <- Deferred[F, FetchStatus]
+          request = FetchOne(id, ds)
+          result = deferred.complete _
+          blocked = BlockedRequest(request, result)
+          anyDs = ds.asInstanceOf[DataSource[Any, Any]]
+          blockedRequest = RequestMap(Map(anyDs -> blocked))
+        } yield Blocked(blockedRequest, Unfetch[F, Option[A]](
+          deferred.get.map {
+            case FetchDone(a) =>
+              Done(Some(a)).asInstanceOf[FetchResult[F, Option[A]]]
+            case FetchMissing() =>
+              Done(None).asInstanceOf[FetchResult[F, Option[A]]]
+          }
+        ))
+      )
+
     // Running a Fetch
 
     /**

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -18,16 +18,15 @@ package fetch
 
 import org.scalatest.{AsyncFreeSpec, Matchers}
 
-import fetch._
-
 import scala.concurrent._
 import scala.concurrent.duration._
 
 import cats._
+import cats.temp.par._
 import cats.effect._
 import cats.instances.list._
+import cats.instances.option._
 import cats.data.NonEmptyList
-import cats.syntax.cartesian._
 import cats.syntax.all._
 
 class FetchTests extends AsyncFreeSpec with Matchers {
@@ -716,5 +715,48 @@ class FetchTests extends AsyncFreeSpec with Matchers {
       .map(_ should matchPattern {
         case Left(MissingIdentity(Never(), _, _)) =>
       }).unsafeToFuture
+  }
+
+  // Optional fetches
+
+  case class MaybeMissing(id: Int)
+
+  object MaybeMissingSource extends DataSource[MaybeMissing, Int] {
+    override def name = "Maybe Missing Source"
+
+    override def fetch[F[_]](id: MaybeMissing)(
+      implicit CF: ConcurrentEffect[F], P: Par[F]
+    ): F[Option[Int]] =
+      if (id.id % 2 == 0)
+        Applicative[F].pure(None)
+      else
+        Applicative[F].pure(Option(id.id))
+  }
+
+  def maybeOpt[F[_] : ConcurrentEffect](id: Int): Fetch[F, Option[Int]] =
+    Fetch.optional(MaybeMissing(id), MaybeMissingSource)
+
+  "We can run optional fetches" in {
+    def fetch[F[_] : ConcurrentEffect]: Fetch[F, Option[Int]] =
+      maybeOpt(1)
+
+    Fetch.run[IO](fetch).map(_ shouldEqual Some(1)).unsafeToFuture
+  }
+
+  "We can run optional fetches with traverse" in {
+    def fetch[F[_] : ConcurrentEffect]: Fetch[F, List[Int]] =
+      List(1, 2, 3).traverse(maybeOpt[F]).map(_.flatten)
+
+    Fetch.run[IO](fetch).map(_ shouldEqual List(1, 3)).unsafeToFuture
+  }
+
+  "We can run optional fetches with other data sources" in {
+    def fetch[F[_] : ConcurrentEffect]: Fetch[F, List[Int]] = {
+      val ones = List(1, 2, 3).traverse(one[F])
+      val maybes = List(1, 2, 3).traverse(maybeOpt[F])
+      (ones, maybes).mapN { case (os, ms) => os ++ ms.flatten }
+    }
+
+    Fetch.run[IO](fetch).map(_ shouldEqual List(1, 2, 3, 1, 3)).unsafeToFuture
   }
 }


### PR DESCRIPTION
You can create `Fetch` values with `Fetch#optional` instead of `Fetch#apply` and you'll get back a `Fetch[F, Option[A]]` instead of a `Fetch[F, A]`. 

I still want to experiment working with optional fetches using `OptionT` but this change solves #45 

 - [ ] Update docs
 - [ ] Add more testing