### PR TITLE
Remove Par typeclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ Summary of changes:
 * `Query` and `FetchMonadError` types deleted
 * `Fetch#traverse`, `Fetch#sequence`, `Fetch#join` & `Fetch#collect` deleted in favor of usign cats typeclass ops
 * Introduction of `cats-effect` for the implementation and target types
-  - `DataSource` in terms of `ConcurrentEffect` from `cats-effect` and `Par` from `cats-par`
+  - `DataSource` in terms of `ConcurrentEffect` from `cats-effect`
   - `DataSourceCache` in terms of `ConcurrentEffect`
-  - `Fetch` is now parameterised to `F[_]` with a `ConcurrentEffect[F]` and `Par[F]`
+  - `Fetch` is now parameterised to `F[_]` with a `ConcurrentEffect[F]`
   - `Fetch#apply` now doesn't require an implicit `DataSource` but it must be provided explicitly
   - `Fetch#run` now requires a `Timer[F]` and `ContextShift[F]` from `cats-effect`
   - Removed Monix, Future and Twitter Future subprojects, most of them should work with `cats-effect` abstractions already

--- a/examples/src/test/scala/DoobieExample.scala
+++ b/examples/src/test/scala/DoobieExample.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import cats.Parallel
-import cats.temp.par._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
@@ -69,10 +67,10 @@ class DoobieExample extends WordSpec with Matchers {
   val authorDS = new DataSource[AuthorId, Author] {
     override def name = "AuthorDoobie"
 
-    override def fetch[F[_]: ConcurrentEffect: Par](id: AuthorId): F[Option[Author]] =
+    override def fetch[F[_]: ConcurrentEffect](id: AuthorId): F[Option[Author]] =
       LiftIO[F].liftIO(fetchById(id).transact(xa))
 
-    override def batch[F[_]: ConcurrentEffect: Par](
+    override def batch[F[_]: ConcurrentEffect](
         ids: NonEmptyList[AuthorId]): F[Map[AuthorId, Author]] =
       LiftIO[F].liftIO(
         fetchByIds(ids)

--- a/examples/src/test/scala/Http4sExample.scala
+++ b/examples/src/test/scala/Http4sExample.scala
@@ -17,12 +17,10 @@
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
 import cats.syntax.all._
-import cats.temp.par._
 
 import io.circe._
 import io.circe.generic.semiauto._
@@ -70,12 +68,12 @@ class Http4sExample extends WordSpec with Matchers {
   object Users extends DataSource[UserId, User] {
     override def name = "UserH4s"
 
-    override def fetch[F[_]: ConcurrentEffect: Par](id: UserId): F[Option[User]] = {
+    override def fetch[F[_]: ConcurrentEffect](id: UserId): F[Option[User]] = {
       val url = s"https://jsonplaceholder.typicode.com/users?id=${id.id}"
       client[F] >>= ((c) => c.expect(url)(jsonOf[F, List[User]]).map(_.headOption))
     }
 
-    override def batch[F[_]: ConcurrentEffect: Par](
+    override def batch[F[_]: ConcurrentEffect](
         ids: NonEmptyList[UserId]
     ): F[Map[UserId, User]] = {
       val filterIds = ids.map("id=" + _.id).toList.mkString("&")
@@ -89,12 +87,12 @@ class Http4sExample extends WordSpec with Matchers {
 
   object Posts extends DataSource[UserId, List[Post]] {
     override def name = "PostH4s"
-    override def fetch[F[_]: ConcurrentEffect: Par](id: UserId): F[Option[List[Post]]] = {
+    override def fetch[F[_]: ConcurrentEffect](id: UserId): F[Option[List[Post]]] = {
       val url = s"https://jsonplaceholder.typicode.com/posts?userId=${id.id}"
       client[F] >>= ((c) => c.expect(url)(jsonOf[F, List[Post]]).map(Option.apply))
     }
 
-    override def batch[F[_]: ConcurrentEffect: Par](
+    override def batch[F[_]: ConcurrentEffect](
         ids: NonEmptyList[UserId]): F[Map[UserId, List[Post]]] = {
       val filterIds = ids.map("userId=" + _.id).toList.mkString("&")
       val url       = s"https://jsonplaceholder.typicode.com/posts?$filterIds"

--- a/examples/src/test/scala/JedisExample.scala
+++ b/examples/src/test/scala/JedisExample.scala
@@ -17,12 +17,10 @@
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
 import cats.syntax.all._
-import cats.temp.par._
 
 import io.circe._
 import io.circe.generic.semiauto._
@@ -66,12 +64,12 @@ object DataSources {
   object Users extends DataSource[UserId, User] {
     override def name = "UserH4s"
 
-    override def fetch[F[_]: ConcurrentEffect: Par](id: UserId): F[Option[User]] = {
+    override def fetch[F[_]: ConcurrentEffect](id: UserId): F[Option[User]] = {
       val url = s"https://jsonplaceholder.typicode.com/users?id=${id.id}"
       client[F] >>= ((c) => c.expect(url)(jsonOf[F, List[User]]).map(_.headOption))
     }
 
-    override def batch[F[_]: ConcurrentEffect: Par](
+    override def batch[F[_]: ConcurrentEffect](
         ids: NonEmptyList[UserId]
     ): F[Map[UserId, User]] = {
       val filterIds = ids.map("id=" + _.id).toList.mkString("&")
@@ -89,7 +87,7 @@ object DataSources {
   object Numbers extends DataSource[Int, Int] {
     override def name = "Numbers"
 
-    override def fetch[F[_]: ConcurrentEffect: Par](id: Int): F[Option[Int]] =
+    override def fetch[F[_]: ConcurrentEffect](id: Int): F[Option[Int]] =
       Sync[F].pure(Option(id))
   }
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,7 +19,6 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val commonCrossDependencies: Seq[ModuleID] =
       Seq(
-        "io.chrisdavenport" %% "cats-par" % "0.2.0",
         "org.typelevel" %% "cats-effect" % "1.0.0",
           %%("scalatest") % "test")
 

--- a/shared/src/main/scala/cache.scala
+++ b/shared/src/main/scala/cache.scala
@@ -21,7 +21,6 @@ import cats.effect._
 import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.syntax.all._
-import cats.temp.par._
 
 final class DataSourceName(val name: String) extends AnyVal
 final class DataSourceId(val id: Any) extends AnyVal

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -41,7 +41,9 @@ trait DataSource[I, A] {
    */
   def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[I]): F[Map[I, A]] =
     for {
-      fibers <- ids.traverse((id) => Concurrent[F].start(fetch(id)).map((v) => id -> v))
+      fibers <- ids.traverse(
+        (id) => FetchExecution.spawn(fetch(id)).map((v) => id -> v)
+      )
       tuples <- fibers.traverse({ case (id, fiber) => fiber.join.map( id -> _ ) })
       results = tuples.collect({ case (id, Some(x)) => id -> x }).toMap
     } yield results

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -22,7 +22,6 @@ import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.instances.option._
 import cats.syntax.all._
-import cats.temp.par._
 
 /**
  * A `DataSource` is the recipe for fetching a certain identity `I`, which yields
@@ -35,15 +34,15 @@ trait DataSource[I, A] {
 
   /** Fetch one identity, returning a None if it wasn't found.
    */
-  def fetch[F[_] : ConcurrentEffect : Par](id: I): F[Option[A]]
+  def fetch[F[_] : ConcurrentEffect](id: I): F[Option[A]]
 
   /** Fetch many identities, returning a mapping from identities to results. If an
    * identity wasn't found, it won't appear in the keys.
    */
-  def batch[F[_] : ConcurrentEffect : Par](ids: NonEmptyList[I]): F[Map[I, A]] =
-    ids.parTraverse(
+  def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[I]): F[Map[I, A]] =
+    ids.traverse(
       (id) => fetch(id).map(_.tupleLeft(id))
-    ).map(_.collect { case Some(x) => x }.toMap)
+    ).map(_.collect { case Some(x) => x }.toMap) // todo: parallelism
 
   def maxBatchSize: Option[Int] = None
 

--- a/shared/src/main/scala/execution.scala
+++ b/shared/src/main/scala/execution.scala
@@ -28,7 +28,7 @@ private object FetchExecution {
       fibers <- effects.traverse(CF.start(_))
       runFibers = fibers.traverse(_.join)
       _ <- CF.handleErrorWith(runFibers)(error => {
-        fibers.traverse(_.cancel *> CF.raiseError(error))
+        fibers.traverse(_.cancel) *> CF.raiseError(error)
       })
       results <- runFibers
     } yield results

--- a/shared/src/main/scala/execution.scala
+++ b/shared/src/main/scala/execution.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fetch
+
+import cats.effect._
+
+object FetchExecution {
+  /* Spawns a computation that can't be cancelled. Returns a `Fiber` that can be joined to obtain the result of the computation.  */
+  def spawn[F[_] : Concurrent, A](f: F[A]): F[Fiber[F, A]] =
+    Concurrent[F].start(Concurrent[F].uncancelable(f))
+
+}
+

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -419,7 +419,7 @@ object `package` {
         CS: ContextShift[F],
         T: Timer[F]
     ): F[Fiber[F, List[Request]]] =
-      Concurrent[F].start(blocked.request match {
+      FetchExecution.spawn(blocked.request match {
         case q @ FetchOne(id, ds) => runFetchOne[F](q, blocked.result, cache, env)
         case q @ Batch(ids, ds) => runBatch[F](q, blocked.result, cache, env)
       })
@@ -545,7 +545,7 @@ object `package` {
         batches.traverse(q.ds.batch[F])
       case InParallel =>
         for {
-          fibers <- batches.traverse((ids) => Concurrent[F].start(q.ds.batch[F](ids)))
+          fibers <- batches.traverse((ids) => FetchExecution.spawn(q.ds.batch[F](ids)))
           maps <- fibers.traverse(_.join)
         } yield maps
     }

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -544,10 +544,6 @@ object `package` {
         batches.traverse(q.ds.batch[F])
       case InParallel =>
         FetchExecution.parallel(batches.map(q.ds.batch(_)))
-        //for {
-        //  fibers <- batches.traverse((ids) => FetchExecution.spawn(q.ds.batch[F](ids)))
-        //  maps <- fibers.traverse(_.join)
-        //} yield maps
     }
 
     results.map(_.toList.reduce(combineBatchResults)).map(BatchedRequest(reqs, _))

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -546,7 +546,7 @@ object `package` {
       case InParallel =>
         for {
           fibers <- batches.traverse((ids) => Concurrent[F].start(q.ds.batch[F](ids)))
-          maps <- fibers.traverse((fiber) => fiber.join)
+          maps <- fibers.traverse(_.join)
         } yield maps
     }
 

--- a/shared/src/main/scala/syntax.scala
+++ b/shared/src/main/scala/syntax.scala
@@ -17,7 +17,6 @@
 package fetch
 
 import cats._
-import cats.temp.par._
 import cats.effect._
 
 object syntax {

--- a/shared/src/test/scala/FetchAsyncQueryTests.scala
+++ b/shared/src/test/scala/FetchAsyncQueryTests.scala
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-import scala.concurrent.{ExecutionContext, Future}
-
-import org.scalatest.{AsyncFreeSpec, Matchers}
-
 import cats.instances.list._
 import cats.effect._
 import cats.syntax.all._
 
 import fetch._
 
-class FetchAsyncQueryTests extends AsyncFreeSpec with Matchers {
+class FetchAsyncQueryTests extends FetchSpec {
   import DataSources._
-
-  implicit override val executionContext = ExecutionContext.Implicits.global
-  implicit val timer: Timer[IO] = IO.timer(executionContext)
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   "We can interpret an async fetch into an IO" in {
     def fetch[F[_] : ConcurrentEffect]: Fetch[F, Article] =

--- a/shared/src/test/scala/FetchBatchingTests.scala
+++ b/shared/src/test/scala/FetchBatchingTests.scala
@@ -21,7 +21,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.scalatest.{AsyncFreeSpec, Matchers}
 
 import cats._
-import cats.temp.par._
 import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.syntax.all._
@@ -41,7 +40,7 @@ class FetchBatchingTests extends AsyncFreeSpec with Matchers {
   object MaxBatchSourceSeq extends DataSource[BatchedDataSeq, Int] {
     override def name = "BatchSourceSeq"
 
-    override def fetch[F[_] : ConcurrentEffect : Par](id: BatchedDataSeq): F[Option[Int]] =
+    override def fetch[F[_] : ConcurrentEffect](id: BatchedDataSeq): F[Option[Int]] =
       Applicative[F].pure(Some(id.id))
 
     override val maxBatchSize = Some(2)
@@ -54,7 +53,7 @@ class FetchBatchingTests extends AsyncFreeSpec with Matchers {
   object MaxBatchSourcePar extends DataSource[BatchedDataPar, Int] {
     override def name = "BatchSourcePar"
 
-    override def fetch[F[_] : ConcurrentEffect : Par](id: BatchedDataPar): F[Option[Int]] =
+    override def fetch[F[_] : ConcurrentEffect](id: BatchedDataPar): F[Option[Int]] =
       Applicative[F].pure(Some(id.id))
 
     override val maxBatchSize = Some(2)

--- a/shared/src/test/scala/FetchBatchingTests.scala
+++ b/shared/src/test/scala/FetchBatchingTests.scala
@@ -16,10 +16,6 @@
 
 package fetch
 
-import scala.concurrent.{ExecutionContext, Future}
-
-import org.scalatest.{AsyncFreeSpec, Matchers}
-
 import cats._
 import cats.data.NonEmptyList
 import cats.instances.list._
@@ -28,12 +24,8 @@ import cats.effect._
 
 import fetch._
 
-class FetchBatchingTests extends AsyncFreeSpec with Matchers {
+class FetchBatchingTests extends FetchSpec {
   import TestHelper._
-
-  override val executionContext: ExecutionContext = ExecutionContext.Implicits.global
-  implicit val timer: Timer[IO] = IO.timer(executionContext)
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   case class BatchedDataSeq(id: Int)
 

--- a/shared/src/test/scala/FetchReportingTests.scala
+++ b/shared/src/test/scala/FetchReportingTests.scala
@@ -16,22 +16,12 @@
 
 package fetch
 
-import scala.concurrent.{ExecutionContext, Future}
-
-import org.scalatest.{AsyncFreeSpec, Matchers}
-
-import fetch._
-
 import cats.effect._
 import cats.instances.list._
 import cats.syntax.all._
 
-class FetchReportingTests extends AsyncFreeSpec with Matchers {
+class FetchReportingTests extends FetchSpec {
   import TestHelper._
-
-  override implicit val executionContext = ExecutionContext.Implicits.global
-  implicit val timer: Timer[IO] = IO.timer(executionContext)
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   "Plain values have no rounds of execution" in {
     def fetch[F[_] : ConcurrentEffect] =

--- a/shared/src/test/scala/FetchSpec.scala
+++ b/shared/src/test/scala/FetchSpec.scala
@@ -26,7 +26,7 @@ import cats.effect._
 
 @DoNotDiscover
 class FetchSpec extends AsyncFreeSpec with Matchers {
-  override val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+  override val executionContext: ExecutionContext = ExecutionContext.Implicits.global
   implicit val timer: Timer[IO] = IO.timer(executionContext)
   implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 

--- a/shared/src/test/scala/FetchSpec.scala
+++ b/shared/src/test/scala/FetchSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fetch
+
+import org.scalatest.{AsyncFreeSpec, Matchers, DoNotDiscover}
+
+import scala.concurrent._
+import java.util.concurrent._
+import scala.concurrent.duration._
+
+import cats.effect._
+
+@DoNotDiscover
+class FetchSpec extends AsyncFreeSpec with Matchers {
+  override val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+  implicit val timer: Timer[IO] = IO.timer(executionContext)
+  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
+
+  def countFetches(r: Request): Int =
+    r.request match {
+      case FetchOne(_, _)       => 1
+      case Batch(ids, _)    => ids.toList.size
+    }
+
+  def totalFetched(rs: Seq[Round]): Int =
+    rs.map((round: Round) => round.queries.map(countFetches).sum).toList.sum
+
+  def countBatches(r: Request): Int =
+    r.request match {
+      case FetchOne(_, _)    => 0
+      case Batch(_, _) => 1
+    }
+
+  def totalBatches(rs: Seq[Round]): Int =
+    rs.map((round: Round) => round.queries.map(countBatches).sum).toList.sum
+}

--- a/shared/src/test/scala/FetchSyntaxTests.scala
+++ b/shared/src/test/scala/FetchSyntaxTests.scala
@@ -16,22 +16,13 @@
 
 package fetch
 
-import scala.concurrent.{ExecutionContext, Future}
-
-import org.scalatest.{AsyncFreeSpec, Matchers}
-
 import cats.syntax.all._
 import cats.effect._
 
-import fetch._
 import fetch.syntax._
 
-class FetchSyntaxTests extends AsyncFreeSpec with Matchers {
+class FetchSyntaxTests extends FetchSpec {
   import TestHelper._
-
-  override val executionContext: ExecutionContext = ExecutionContext.Implicits.global
-  implicit val timer: Timer[IO] = IO.timer(executionContext)
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   "`fetch` syntax allows lifting of any value to the context of a fetch" in {
     Fetch.pure[IO, Int](42) shouldEqual 42.fetch[IO]

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -19,6 +19,7 @@ package fetch
 import org.scalatest.{AsyncFreeSpec, Matchers}
 
 import scala.concurrent._
+import java.util.concurrent._
 import scala.concurrent.duration._
 
 import cats._
@@ -28,12 +29,8 @@ import cats.instances.option._
 import cats.data.NonEmptyList
 import cats.syntax.all._
 
-class FetchTests extends AsyncFreeSpec with Matchers {
+class FetchTests extends FetchSpec {
   import TestHelper._
-
-  override val executionContext: ExecutionContext = ExecutionContext.Implicits.global
-  implicit val timer: Timer[IO] = IO.timer(executionContext)
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   // Fetch ops
 

--- a/shared/src/test/scala/TestHelper.scala
+++ b/shared/src/test/scala/TestHelper.scala
@@ -18,7 +18,6 @@ package fetch
 
 import cats._
 import cats.effect._
-import cats.temp.par._
 import cats.data.NonEmptyList
 
 import scala.collection.immutable.Map
@@ -33,19 +32,19 @@ object TestHelper {
     override def name = "OneSource"
 
     override def fetch[F[_]](id: One)(
-      implicit CF: ConcurrentEffect[F], P: Par[F]
+      implicit CF: ConcurrentEffect[F]
     ): F[Option[Int]] =
       Applicative[F].pure(Option(id.id))
 
     override def batch[F[_]](ids: NonEmptyList[One])(
-      implicit CF: ConcurrentEffect[F], P: Par[F]
+      implicit CF: ConcurrentEffect[F]
     ): F[Map[One, Int]] =
       Applicative[F].pure(
         ids.toList.map((v) => (v, v.id)).toMap
       )
   }
 
-  def one[F[_] : ConcurrentEffect : Par](id: Int): Fetch[F, Int] =
+  def one[F[_] : ConcurrentEffect](id: Int): Fetch[F, Int] =
     Fetch(One(id), OneSource)
 
   case class Many(n: Int)
@@ -53,11 +52,11 @@ object TestHelper {
   object ManySource extends DataSource[Many, List[Int]] {
     override def name = "ManySource"
 
-    override def fetch[F[_] : ConcurrentEffect : Par](id: Many): F[Option[List[Int]]] =
+    override def fetch[F[_] : ConcurrentEffect](id: Many): F[Option[List[Int]]] =
       Applicative[F].pure(Option(0 until id.n toList))
   }
 
-  def many[F[_] : ConcurrentEffect : Par](id: Int): Fetch[F, List[Int]] =
+  def many[F[_] : ConcurrentEffect](id: Int): Fetch[F, List[Int]] =
     Fetch(Many(id), ManySource)
 
   case class AnotherOne(id: Int)
@@ -65,16 +64,16 @@ object TestHelper {
   object AnotheroneSource extends DataSource[AnotherOne, Int] {
     override def name = "AnotherOneSource"
 
-    override def fetch[F[_] : ConcurrentEffect : Par](id: AnotherOne): F[Option[Int]] =
+    override def fetch[F[_] : ConcurrentEffect](id: AnotherOne): F[Option[Int]] =
       Applicative[F].pure(Option(id.id))
 
-    override def batch[F[_] : ConcurrentEffect : Par](ids: NonEmptyList[AnotherOne]): F[Map[AnotherOne, Int]] =
+    override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[AnotherOne]): F[Map[AnotherOne, Int]] =
       Applicative[F].pure(
         ids.toList.map((v) => (v, v.id)).toMap
       )
   }
 
-  def anotherOne[F[_] : ConcurrentEffect : Par](id: Int): Fetch[F, Int] =
+  def anotherOne[F[_] : ConcurrentEffect](id: Int): Fetch[F, Int] =
     Fetch(AnotherOne(id), AnotheroneSource)
 
   case class Never()
@@ -82,11 +81,11 @@ object TestHelper {
   object NeverSource extends DataSource[Never, Int] {
     override def name = "NeverSource"
 
-    override def fetch[F[_] : ConcurrentEffect : Par](id: Never): F[Option[Int]] =
+    override def fetch[F[_] : ConcurrentEffect](id: Never): F[Option[Int]] =
       Applicative[F].pure(None : Option[Int])
   }
 
-  def never[F[_] : ConcurrentEffect : Par]: Fetch[F, Int] =
+  def never[F[_] : ConcurrentEffect]: Fetch[F, Int] =
     Fetch(Never(), NeverSource)
 
   // Check Env

--- a/shared/src/test/scala/TestHelper.scala
+++ b/shared/src/test/scala/TestHelper.scala
@@ -88,23 +88,4 @@ object TestHelper {
   def never[F[_] : ConcurrentEffect]: Fetch[F, Int] =
     Fetch(Never(), NeverSource)
 
-  // Check Env
-
-  def countFetches(r: Request): Int =
-    r.request match {
-      case FetchOne(_, _)       => 1
-      case Batch(ids, _)    => ids.toList.size
-    }
-
-  def totalFetched(rs: Seq[Round]): Int =
-    rs.map((round: Round) => round.queries.map(countFetches).sum).toList.sum
-
-  def countBatches(r: Request): Int =
-    r.request match {
-      case FetchOne(_, _)    => 0
-      case Batch(_, _) => 1
-    }
-
-  def totalBatches(rs: Seq[Round]): Int =
-    rs.map((round: Round) => round.queries.map(countBatches).sum).toList.sum
 }

--- a/tut/README.md
+++ b/tut/README.md
@@ -59,12 +59,11 @@ Data Sources take two type parameters:
 ```scala
 import cats.data.NonEmptyList
 import cats.effect.ConcurrentEffect
-import cats.temp.par.Par
 
 trait DataSource[Identity, Result]{
   def name: String
-  def fetch[F[_] : ConcurrentEffect : Par](id: Identity): F[Option[Result]]
-  def batch[F[_] : ConcurrentEffect : Par](ids: NonEmptyList[Identity]): F[Map[Identity, Result]]
+  def fetch[F[_] : ConcurrentEffect](id: Identity): F[Option[Result]]
+  def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Identity]): F[Map[Identity, Result]]
 }
 ```
 
@@ -75,7 +74,6 @@ We'll implement a dummy data source that can convert integers to strings. For co
 ```tut:silent
 import cats.data.NonEmptyList
 import cats.effect._
-import cats.temp.par._
 import cats.instances.list._
 import cats.syntax.all._
 
@@ -84,13 +82,13 @@ import fetch._
 object ToStringSource extends DataSource[Int, String]{
   override def name = "ToString"
 
-  override def fetch[F[_] : ConcurrentEffect : Par](id: Int): F[Option[String]] = {
+  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
     Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id")) >>
     Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id")) >>
     Sync[F].pure(Option(id.toString))
   }
 
-  override def batch[F[_] : ConcurrentEffect : Par](ids: NonEmptyList[Int]): F[Map[Int, String]] = {
+  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Int]): F[Map[Int, String]] = {
     Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids")) >>
     Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids")) >>
     Sync[F].pure(ids.toList.map(i => (i, i.toString)).toMap)
@@ -158,7 +156,7 @@ Note that the `DataSource#batch` method is not mandatory, it will be implemented
 object UnbatchedToStringSource extends DataSource[Int, String]{
   override def name = "UnbatchedToString"
 
-  override def fetch[F[_] : ConcurrentEffect : Par](id: Int): F[Option[String]] = {
+  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
     Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
     Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
     Sync[F].pure(Option(id.toString))
@@ -190,12 +188,12 @@ If we combine two independent fetches from different data sources, the fetches c
 object LengthSource extends DataSource[String, Int]{
   override def name = "Length"
 
-  override def fetch[F[_] : ConcurrentEffect : Par](id: String): F[Option[Int]] = {
+  override def fetch[F[_] : ConcurrentEffect](id: String): F[Option[Int]] = {
     Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One Length $id")) >>
     Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id")) >>
     Sync[F].pure(Option(id.size))
   }
-  override def batch[F[_] : ConcurrentEffect : Par](ids: NonEmptyList[String]): F[Map[String, Int]] = {
+  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[String]): F[Map[String, Int]] = {
     Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids")) >>
     Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids")) >>
     Sync[F].pure(ids.toList.map(i => (i, i.size)).toMap)


### PR DESCRIPTION
After discussing with @peterneyens how we could get rid of the `Par` typeclass he suggested using `Concurrent#start` and `Fiber`s to achieve parallelism whenever we used `parTraverse`. This is my first approach to implementing it.

- Removes `cats-par` dependency
- Removes `Par` implicit requirement 
- Implements parallelism in terms of `Concurrrent#start` and `Fiber`'s
- [x] Support cancellation of parallel fetches