### PR TITLE
Add F[_] type parameter to DataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ Data Sources take two type parameters:
 import cats.data.NonEmptyList
 import cats.effect.ConcurrentEffect
 
-trait DataSource[Identity, Result]{
-  def name: String
-  def fetch[F[_] : ConcurrentEffect](id: Identity): F[Option[Result]]
-  def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Identity]): F[Map[Identity, Result]]
+trait DataSource[F[_], Identity, Result]{
+  def data: Data[Identity, Result]
+  def fetch(id: Identity): F[Option[Result]]
+  def batch(ids: NonEmptyList[Identity])(
+    implicit E: ConcurrentEffect[F]
+  ): F[Map[Identity, Result]]
 }
 ```
 
@@ -65,31 +67,39 @@ Returning `ConcurrentEffect` instances from the fetch methods allows us to speci
 We'll implement a dummy data source that can convert integers to strings. For convenience, we define a `fetchString` function that lifts identities (`Int` in our dummy data source) to a `Fetch`.
 
 ```scala
+import cats._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
+import cats.implicits._
 import cats.syntax.all._
 
 import fetch._
 
-object ToStringSource extends DataSource[Int, String]{
-  override def name = "ToString"
+object ToString extends Data[Int, String] {
+  def name = "To String"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id")) >>
-    Sync[F].pure(Option(id.toString))
-  }
+  def source[F[_] : Monad]: DataSource[F, Int, String] = new DataSource[F, Int, String]{
+    override def data = ToString
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Int]): F[Map[Int, String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids")) >>
-    Sync[F].pure(ids.toList.map(i => (i, i.toString)).toMap)
+    override def fetch(id: Int)(
+      implicit E: ConcurrentEffect[F]
+    ): F[Option[String]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id"))
+    } yield Option(id.toString)
+
+    override def batch(ids: NonEmptyList[Int])(
+      implicit E: ConcurrentEffect[F]
+    ): F[Map[Int, String]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids"))
+    } yield ids.toList.map(i => (i, i.toString)).toMap
   }
 }
 
 def fetchString[F[_] : ConcurrentEffect](n: Int): Fetch[F, String] =
-  Fetch(n, ToStringSource)
+  Fetch(n, ToString.source)
 ```
 
 ## Creating a runtime
@@ -125,8 +135,8 @@ import scala.concurrent.duration._
 // import scala.concurrent.duration._
 
 Fetch.run[IO](fetchOne).unsafeRunTimed(5.seconds)
-// --> [179] One ToString 1
-// <-- [179] One ToString 1
+// --> [109] One ToString 1
+// <-- [109] One ToString 1
 // res0: Option[String] = Some(1)
 ```
 
@@ -145,26 +155,31 @@ When executing the above fetch, note how the three identities get batched and th
 
 ```scala
 Fetch.run[IO](fetchThree).unsafeRunTimed(5.seconds)
-// --> [179] Batch ToString NonEmptyList(1, 2, 3)
-// <-- [179] Batch ToString NonEmptyList(1, 2, 3)
+// --> [109] Batch ToString NonEmptyList(1, 2, 3)
+// <-- [109] Batch ToString NonEmptyList(1, 2, 3)
 // res1: Option[(String, String, String)] = Some((1,2,3))
 ```
 
 Note that the `DataSource#batch` method is not mandatory, it will be implemented in terms of `DataSource#fetch` if you don't provide an implementation.
 
 ```scala
-object UnbatchedToStringSource extends DataSource[Int, String]{
-  override def name = "UnbatchedToString"
+object UnbatchedToString extends Data[Int, String] {
+  def name = "Unbatched to string"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-    Sync[F].pure(Option(id.toString))
+  def source[F[_]] = new DataSource[F, Int, String] {
+    override def data = UnbatchedToString
+
+    override def fetch(id: Int)(
+      implicit E: ConcurrentEffect[F] 
+    ): F[Option[String]] = 
+      E.delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      E.delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      E.pure(Option(id.toString))
   }
 }
 
 def unbatchedString[F[_] : ConcurrentEffect](n: Int): Fetch[F, String] =
-  Fetch(n, UnbatchedToStringSource)
+  Fetch(n, UnbatchedToString.source)
 ```
 
 Let's create a tuple of unbatched string requests.
@@ -178,12 +193,12 @@ When executing the above fetch, note how the three identities get requested in p
 
 ```scala
 Fetch.run[IO](fetchUnbatchedThree).unsafeRunTimed(5.seconds)
-// --> [179] One UnbatchedToString 1
-// --> [181] One UnbatchedToString 3
-// <-- [181] One UnbatchedToString 3
-// --> [182] One UnbatchedToString 2
-// <-- [182] One UnbatchedToString 2
-// <-- [179] One UnbatchedToString 1
+// --> [109] One UnbatchedToString 1
+// --> [112] One UnbatchedToString 3
+// --> [111] One UnbatchedToString 2
+// <-- [112] One UnbatchedToString 3
+// <-- [109] One UnbatchedToString 1
+// <-- [111] One UnbatchedToString 2
 // res2: Option[(String, String, String)] = Some((1,2,3))
 ```
 
@@ -192,23 +207,30 @@ Fetch.run[IO](fetchUnbatchedThree).unsafeRunTimed(5.seconds)
 If we combine two independent fetches from different data sources, the fetches can be run in parallel. First, let's add a data source that fetches a string's size.
 
 ```scala
-object LengthSource extends DataSource[String, Int]{
-  override def name = "Length"
+object Length extends Data[String, Int] {
+  def name = "Length"
 
-  override def fetch[F[_] : ConcurrentEffect](id: String): F[Option[Int]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One Length $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id")) >>
-    Sync[F].pure(Option(id.size))
-  }
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[String]): F[Map[String, Int]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids")) >>
-    Sync[F].pure(ids.toList.map(i => (i, i.size)).toMap)
+  def source[F[_]] = new DataSource[F, String, Int] {
+    override def data = Length
+
+    override def fetch(id: String)(
+      implicit E: ConcurrentEffect[F]
+    ): F[Option[Int]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One Length $id"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id"))
+    } yield Option(id.size)
+
+      override def batch(ids: NonEmptyList[String])(
+        implicit E: ConcurrentEffect[F]
+      ): F[Map[String, Int]] = for {
+        _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids"))
+        _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids"))
+      } yield ids.toList.map(i => (i, i.size)).toMap
   }
 }
 
 def fetchLength[F[_] : ConcurrentEffect](s: String): Fetch[F, Int] =
-  Fetch(s, LengthSource)
+  Fetch(s, Length.source)
 ```
 
 And now we can easily receive data from the two sources in a single fetch.
@@ -222,10 +244,10 @@ Note how the two independent data fetches run in parallel, minimizing the latenc
 
 ```scala
 Fetch.run[IO](fetchMulti).unsafeRunTimed(5.seconds)
-// --> [181] One ToString 1
-// <-- [181] One ToString 1
-// --> [180] One Length one
-// <-- [180] One Length one
+// --> [112] One ToString 1
+// <-- [112] One ToString 1
+// --> [110] One Length one
+// <-- [110] One Length one
 // res3: Option[(String, Int)] = Some((1,3))
 ```
 
@@ -246,8 +268,8 @@ While running it, notice that the data source is only queried once. The next tim
 
 ```scala
 Fetch.run[IO](fetchTwice).unsafeRunTimed(5.seconds)
-// --> [182] One ToString 1
-// <-- [182] One ToString 1
+// --> [109] One ToString 1
+// <-- [109] One ToString 1
 // res4: Option[(String, String)] = Some((1,1))
 ```
 
@@ -257,7 +279,6 @@ Fetch.run[IO](fetchTwice).unsafeRunTimed(5.seconds)
 ---
 
 For more in-depth information take a look at our [documentation](http://47deg.github.io/fetch/docs.html).
-
 
 ## Fetch in the wild
 

--- a/debug/shared/src/main/scala/debug.scala
+++ b/debug/shared/src/main/scala/debug.scala
@@ -81,21 +81,21 @@ object debug {
   }
 
   def showRequest(r: Request): Document = r.request match {
-    case FetchOne(id, ds) =>
-      Document.text(s"[Fetch one] From `${ds.name}` with id ${id}") :: showDuration(r.duration)
-    case Batch(ids, ds) =>
-      Document.text(s"[Batch] From `${ds.name}` with ids ${ids.toList}") :: showDuration(r.duration)
+    case FetchOne(id, d) =>
+      Document.text(s"[Fetch one] From `${d.name}` with id ${id}") :: showDuration(r.duration)
+    case Batch(ids, d) =>
+      Document.text(s"[Batch] From `${d.name}` with ids ${ids.toList}") :: showDuration(r.duration)
   }
 
-  def showMissing(ds: DataSource[_, _], ids: List[_]): Document =
-    Document.text(s"`${ds.name}` missing identities ${ids}")
+  def showMissing(d: Data[_, _], ids: List[_]): Document =
+    Document.text(s"`${d.name}` missing identities ${ids}")
 
   def showRoundCount(err: FetchException): Document =
     Document.text(s", fetch interrupted after ${err.environment.rounds.size} rounds")
 
   def showException(err: FetchException): Document = err match {
     case MissingIdentity(id, q, env) =>
-      Document.text(s"[ERROR] Identity with id `${id}` for data source `${q.dataSource.name}` not found") :: showRoundCount(err)
+      Document.text(s"[ERROR] Identity with id `${id}` for data source `${q.data.name}` not found") :: showRoundCount(err)
     case UnhandledException(exc, env) =>
       Document
         .text(s"[ERROR] Unhandled `${exc.getClass.getName}`: '${exc.getMessage}'") :: showRoundCount(err)

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -64,15 +64,15 @@ If something is missing in Fetch that stops you from using it we'd appreciate if
 
 # Usage
 
-In order to tell Fetch how to retrieve data, we must implement the `DataSource` typeclass.
+In order to tell Fetch how to retrieve data, we must implement the `DataSource` typeclass. The `Data` typeclass is to tell Fetch which kind of data the source is fetching, and is used to optimize requests for the same data.
 
 ```scala
 import cats.effect.ConcurrentEffect
 import cats.data.NonEmptyList
 
 trait DataSource[Identity, Result]{
-  def name: String
-  
+  def data: Data[Identity, Result]
+
   def fetch[F[_] : ConcurrentEffect](id: Identity): F[Option[Result]]
   
   /* `batch` is implemented in terms of `fetch` by default */
@@ -94,6 +94,7 @@ a map from identities to results. Accepting a list of identities gives Fetch the
 the same data source, and returning a mapping from identities to results, Fetch can detect whenever an identity
 couldn't be fetched or no longer exists.
 
+The `data` method returns a `Data[Identity, Result]` instance that Fetch uses to optimize requests to the same data source, and is expected to return a singleton `object` that extends `Data[Identity, Result]`.
 
 ## Writing your first data source
 
@@ -131,23 +132,31 @@ val userDatabase: Map[UserId, User] = Map(
   4 -> User(4, "@four")
 )
 
-object UserSource extends DataSource[UserId, User]{
-  override def name = "User"
+object Users extends Data[UserId, User] {
+  def name = "Users"
 
-  override def fetch[F[_] : ConcurrentEffect](id: UserId): F[Option[User]] =
-    latency(userDatabase.get(id), s"One User $id")
+  def source[F[_]]: DataSource[F, UserId, User] = new DataSource[F, UserId, User] {
+      override def data = Users
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[UserId]): F[Map[UserId, User]] =
-    latency(userDatabase.filterKeys(ids.toList.toSet), s"Batch Users $ids")
+      override def fetch(id: UserId)(
+        implicit CF: ConcurrentEffect[F]
+      ): F[Option[User]] =
+        latency(userDatabase.get(id), s"One User $id")
+
+      override def batch(ids: NonEmptyList[UserId])(
+        implicit CF: ConcurrentEffect[F]
+      ): F[Map[UserId, User]] =
+        latency(userDatabase.filterKeys(ids.toList.toSet), s"Batch Users $ids")
+    }
 }
 ```
 
 Now that we have a data source we can write a function for fetching users
-given an id, we just have to pass a `UserId` and the data source as arguments to `Fetch`.
+given a `DataSource`, an id and the data source as arguments to `Fetch`.
 
 ```tut:silent
 def getUser[F[_] : ConcurrentEffect](id: UserId): Fetch[F, User] =
-  Fetch(id, UserSource)
+  Fetch(id, Users.source)
 ```
 
 ### Optional identities
@@ -156,7 +165,7 @@ If you want to create a Fetch that doesn't fail if the identity is not found, yo
 
 ```tut:silent
 def maybeGetUser[F[_] : ConcurrentEffect](id: UserId): Fetch[F, Option[User]] =
-  Fetch.optional(id, UserSource)
+  Fetch.optional(id, Users.source)
 ```
 
 ### Data sources that don't support batching
@@ -164,11 +173,17 @@ def maybeGetUser[F[_] : ConcurrentEffect](id: UserId): Fetch[F, Option[User]] =
 If your data source doesn't support batching, you can simply leave the `batch` method unimplemented. Note that it will use the `fetch` implementation for requesting identities in parallel.
 
 ```tut:silent
-implicit object UnbatchedSource extends DataSource[Int, Int]{
-  override def name = "Unbatched"
+object Unbatched extends Data[Int, Int]{
+  def name = "Unbatched"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[Int]] =
-    Sync[F].pure(Option(id))
+  def source[F[_]]: DataSource[F, Int, Int] = new DataSource[F, Int, Int]{
+    override def data = Unbatched
+
+    override def fetch(id: Int)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[Int]] =
+      CF.pure(Option(id))
+  }
 }
 ```
 
@@ -176,17 +191,25 @@ implicit object UnbatchedSource extends DataSource[Int, Int]{
 
 The default `batch` implementation run requests to the data source in parallel, but you can easily override it. We can make `batch` sequential using `NonEmptyList.traverse` for fetching individual identities.
 
-```tut:silent
-object UnbatchedSeqSource extends DataSource[Int, Int]{
-  override def name = "UnbatchedSeq"
+```scala
+object UnbatchedSeq extends Data[Int, Int]{
+  def name = "UnbatchedSeq"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[Int]] =
-    Sync[F].pure(Option(id))
-    
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Int]): F[Map[Int, Int]] =
-    ids.traverse(
-      (id) => fetch(id).map(v => (id, v))
-    ).map(_.collect { case (i, Some(x)) => (i, x) }.toMap)
+  def source[F[_]]: DataSource[F, Int, Int] = new DataSource[F, Int, Int]{
+    override def data = UnbatchedSeq
+
+    override def fetch(id: Int)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[Int]] =
+      CF.pure(Option(id))
+
+    override def batch(ids: NonEmptyList[Int])(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Map[Int, Int]] =
+      ids.traverse(
+        (id) => fetch(id).map(v => (id, v))
+      ).map(_.collect { case (i, Some(x)) => (i, x) }.toMap)
+  }
 }
 ```
 
@@ -196,14 +219,22 @@ object UnbatchedSeqSource extends DataSource[Int, Int]{
 If your data source only supports querying it in batches, you can implement `fetch` in terms of `batch`.
 
 ```tut:silent
-object OnlyBatchedSource extends DataSource[Int, Int]{
-  override def name = "OnlyBatched"
+object OnlyBatched extends Data[Int, Int]{
+  def name = "OnlyBatched"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[Int]] =
-    batch(NonEmptyList(id, List())).map(_.get(id))
+  def source[F[_]]: DataSource[F, Int, Int] = new DataSource[F, Int, Int]{
+    override def data = OnlyBatched
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Int]): F[Map[Int, Int]] =
-    Sync[F].pure(ids.map(x => (x, x)).toList.toMap)
+    override def fetch(id: Int)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[Int]] =
+      batch(NonEmptyList(id, List())).map(_.get(id))
+
+    override def batch(ids: NonEmptyList[Int])(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Map[Int, Int]] =
+      CF.pure(ids.map(x => (x, x)).toList.toMap)
+  }
 }
 ```
 
@@ -237,7 +268,7 @@ def fetchUser[F[_] : ConcurrentEffect]: Fetch[F, User] =
 
 A `Fetch` is just a value, and in order to be able to get its value we need to run it to an `IO` first. 
 
-```tut:book
+```tut:silent
 import cats.effect.IO
 
 Fetch.run[IO](fetchUser)
@@ -344,18 +375,26 @@ val postDatabase: Map[PostId, Post] = Map(
   3 -> Post(3, 4, "Yet another article")
 )
 
-implicit object PostSource extends DataSource[PostId, Post]{
-  override def name = "Post"
+object Posts extends Data[PostId, Post] {
+  def name = "Posts"
 
-  override def fetch[F[_] : ConcurrentEffect](id: PostId): F[Option[Post]] =
-    latency(postDatabase.get(id), s"One Post $id")
+  def source[F[_]]: DataSource[F, PostId, Post] = new DataSource[F, PostId, Post] {
+    override def data = Posts 
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[PostId]): F[Map[PostId, Post]] =
-    latency(postDatabase.filterKeys(ids.toList.toSet), s"Batch Posts $ids")
+    override def fetch(id: PostId)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[Post]] =
+      latency(postDatabase.get(id), s"One Post $id")
+
+    override def batch(ids: NonEmptyList[PostId])(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Map[PostId, Post]] =
+      latency(postDatabase.filterKeys(ids.toList.toSet), s"Batch Posts $ids")
+  }
 }
 
 def getPost[F[_] : ConcurrentEffect](id: PostId): Fetch[F, Post] =
-  Fetch(id, PostSource)
+  Fetch(id, Posts.source)
 ```
 
 Apart from posts, we are going to add another data source: one for post topics.
@@ -367,22 +406,30 @@ type PostTopic = String
 We'll implement a data source for retrieving a post topic given a post id.
 
 ```tut:silent
-implicit object PostTopicSource extends DataSource[Post, PostTopic]{
-  override def name = "Post topic"
+object PostTopics extends Data[Post, PostTopic] {
+  def name = "Post Topics"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Post): F[Option[PostTopic]] = {
-    val topic = if (id.id % 2 == 0) "monad" else "applicative"
-    latency(Option(topic), s"One Post Topic $id")
-  }
+  def source[F[_]]: DataSource[F, Post, PostTopic] = new DataSource[F, Post, PostTopic] {
+    override def data = PostTopics 
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Post]): F[Map[Post, PostTopic]] = {
-    val result = ids.toList.map(id => (id, if (id.id % 2 == 0) "monad" else "applicative")).toMap
-    latency(result, s"Batch Post Topics $ids")
+    override def fetch(id: Post)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[PostTopic]] = {
+      val topic = if (id.id % 2 == 0) "monad" else "applicative"
+      latency(Option(topic), s"One Post Topic $id")
+    }
+
+    override def batch(ids: NonEmptyList[Post])(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Map[Post, PostTopic]] = {
+      val result = ids.toList.map(id => (id, if (id.id % 2 == 0) "monad" else "applicative")).toMap
+      latency(result, s"Batch Post Topics $ids")
+    }
   }
 }
 
 def getPostTopic[F[_] : ConcurrentEffect](post: Post): Fetch[F, PostTopic] =
-  Fetch(post, PostTopicSource)
+  Fetch(post, PostTopics.source)
 ```
 
 Now that we have multiple sources let's mix them in the same fetch.
@@ -479,8 +526,8 @@ We'll be using the default in-memory cache, prepopulated with some data. The cac
 is calculated with the `DataSource`'s `name` method and the request identity.
 
 ```tut:silent
-def cache[F[_] : ConcurrentEffect] = InMemoryCache.from[F, Int, User](
- (UserSource.name, 1) -> User(1, "@dialelo")
+def cache[F[_] : ConcurrentEffect] = InMemoryCache.from[F, UserId, User](
+ (Users, 1) -> User(1, "purrgrammer")
 )
 ```
 
@@ -519,14 +566,14 @@ Fetch.run[IO](fetchManyUsers, populatedCache).unsafeRunTimed(5.seconds)
 
 ## Implementing a custom cache
 
-The default cache is implemented as an immutable in-memory map, but users are free to use their own caches when running a fetch. Your cache should implement the `DataSourceCache` trait, and after that you can pass it to Fetch's `run` methods.
+The default cache is implemented as an immutable in-memory map, but users are free to use their own caches when running a fetch. Your cache should implement the `DataCache` trait, and after that you can pass it to Fetch's `run` methods.
 
-There is no need for the cache to be mutable since fetch executions run in an interpreter that uses the state monad. Note that the `update` method in the `DataSourceCache` trait yields a new, updated cache.
+There is no need for the cache to be mutable since fetch executions run in an interpreter that uses the state monad. Note that the `update` method in the `DataCache` trait yields a new, updated cache.
 
 ```scala
-trait DataSourceCache[F[_]] {
-  def insert[I, A](i: I, ds: DataSource[I, A], v: A): DataSourceIdentity, v: A): F[DataSourceCache[F]]
-  def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]]
+trait DataCache[F[_]] {
+  def insert[I, A](i: I, v: A, d: Data[I, A]): F[DataCache[F]]
+  def lookup[I, A](i: I, d: Data[I, A]): F[Option[A]]
 }
 ```
 
@@ -535,11 +582,11 @@ Let's implement a cache that forgets everything we store in it.
 ```tut:silent
 import cats.{Applicative, Monad}
 
-case class ForgetfulCache[F[_] : Monad]() extends DataSourceCache[F] {
-  def insert[I, A](i: I, v: A, ds: DataSource[I, A]): F[DataSourceCache[F]] =
+case class ForgetfulCache[F[_] : Monad]() extends DataCache[F] {
+  def insert[I, A](i: I, v: A, d: Data[I, A]): F[DataCache[F]] =
     Applicative[F].pure(this)
 
-  def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]] =
+  def lookup[I, A](i: I, ds: Data[I, A]): F[Option[A]] =
     Applicative[F].pure(None)
 }
 
@@ -568,20 +615,28 @@ When implementing a `DataSource`, there is a method we can override called `maxB
 we can specify the maximum size of the batched requests to this data source, let's try it out:
 
 ```tut:silent
-implicit object BatchedUserSource extends DataSource[UserId, User]{
-  override def name = "BatchedUser"
+object BatchedUsers extends Data[UserId, User]{
+  def name = "Batched Users"
 
-  override def maxBatchSize: Option[Int] = Some(2)
+  def source[F[_]]: DataSource[F, UserId, User] = new DataSource[F, UserId, User] {
+    override def data = BatchedUsers
 
-  override def fetch[F[_] : ConcurrentEffect](id: UserId): F[Option[User]] =
-    latency(userDatabase.get(id), s"One User $id")
+    override def maxBatchSize: Option[Int] = Some(2)
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[UserId]): F[Map[UserId, User]] =
-    latency(userDatabase.filterKeys(ids.toList.toSet), s"Batch Users $ids")
+    override def fetch(id: UserId)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[User]] =
+      latency(userDatabase.get(id), s"One User $id")
+
+    override def batch(ids: NonEmptyList[UserId])(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Map[UserId, User]] =
+      latency(userDatabase.filterKeys(ids.toList.toSet), s"Batch Users $ids")
+  }
 }
 
 def getBatchedUser[F[_] : ConcurrentEffect](id: Int): Fetch[F, User] =
-  Fetch(id, BatchedUserSource)
+  Fetch(id, BatchedUsers.source)
 ```
 
 We have defined the maximum batch size to be 2, let's see what happens when running a fetch that needs more
@@ -599,22 +654,29 @@ Fetch.run[IO](fetchManyBatchedUsers).unsafeRunTimed(5.seconds)
 In the presence of multiple concurrent batches, we can choose between a sequential or parallel execution strategy. By default batches will be run in parallel, but you can tweak this behaviour by overriding `DataSource#batchExection`.
 
 ```tut:silent
-implicit object SequentialUserSource extends DataSource[UserId, User]{
-  override def name = "SequentialUser"
+object SequentialUsers extends Data[UserId, User]{
+  def name = "Sequential Users"
 
-  override def maxBatchSize: Option[Int] = Some(2)
+  def source[F[_]]: DataSource[F, UserId, User] = new DataSource[F, UserId, User] {
+    override def data = SequentialUsers
 
-  override def batchExecution: BatchExecution = Sequentially // defaults to `InParallel`
+    override def maxBatchSize: Option[Int] = Some(2)
+    override def batchExecution: BatchExecution = Sequentially // defaults to `InParallel`
 
-  override def fetch[F[_] : ConcurrentEffect](id: UserId): F[Option[User]] =
-    latency(userDatabase.get(id), s"One User $id")
+    override def fetch(id: UserId)(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Option[User]] =
+      latency(userDatabase.get(id), s"One User $id")
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[UserId]): F[Map[UserId, User]] =
-    latency(userDatabase.filterKeys(ids.toList.toSet), s"Batch Users $ids")
+    override def batch(ids: NonEmptyList[UserId])(
+      implicit CF: ConcurrentEffect[F]
+    ): F[Map[UserId, User]] =
+      latency(userDatabase.filterKeys(ids.toList.toSet), s"Batch Users $ids")
+  }
 }
 
 def getSequentialUser[F[_] : ConcurrentEffect](id: Int): Fetch[F, User] =
-  Fetch(id, SequentialUserSource)
+  Fetch(id, SequentialUsers.source)
 ```
 
 We have defined the maximum batch size to be 2 and the batch execution to be sequential, let's see what happens when running a fetch that needs more than one batch:
@@ -716,7 +778,7 @@ As you can see in the output, the identity `5` for the user source was not found
 ```tut:book
 value match {
   case Left(mi @ MissingIdentity(id, q, e)) => {
-    println("Data Source: " + q.dataSource.name)
+    println("Data: " + q.data.name)
     println("Identity: " + id)
     
     println(describe(mi.environment))
@@ -816,7 +878,7 @@ a fetch execution given an environment.
 Add the following line to your dependencies for including Fetch's debugging facilities:
 
 ```scala
-"com.47deg" %% "fetch-debug" % "0.6.0"
+"com.47deg" %% "fetch-debug" % "1.0.0-RC1"
 ```
 
 ## Fetch execution

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -58,10 +58,9 @@ import cats.effect.ConcurrentEffect
 
 trait DataSource[F[_], Identity, Result]{
   def data: Data[Identity, Result]
+  def CF: ConcurrentEffect[F]
   def fetch(id: Identity): F[Option[Result]]
-  def batch(ids: NonEmptyList[Identity])(
-    implicit E: ConcurrentEffect[F]
-  ): F[Map[Identity, Result]]
+  def batch(ids: NonEmptyList[Identity]): F[Map[Identity, Result]]
 }
 ```
 
@@ -79,24 +78,27 @@ import cats.syntax.all._
 
 import fetch._
 
+def latency[F[_] : Effect](milis: Long): F[Unit] =
+  Effect[F].delay(Thread.sleep(milis))
+
 object ToString extends Data[Int, String] {
   def name = "To String"
 
-  def source[F[_] : Monad]: DataSource[F, Int, String] = new DataSource[F, Int, String]{
+  def source[F[_] : ConcurrentEffect]: DataSource[F, Int, String] = new DataSource[F, Int, String]{
     override def data = ToString
 
-    override def fetch(id: Int)(
-      implicit E: ConcurrentEffect[F]
-    ): F[Option[String]] = for {
-      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id"))
-      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id"))
+    override def CF = ConcurrentEffect[F]
+
+    override def fetch(id: Int): F[Option[String]] = for {
+      _ <- CF.delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id"))
+      _ <- latency(100)
+      _ <- CF.delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id"))
     } yield Option(id.toString)
 
-    override def batch(ids: NonEmptyList[Int])(
-      implicit E: ConcurrentEffect[F]
-    ): F[Map[Int, String]] = for {
-      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids"))
-      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids"))
+    override def batch(ids: NonEmptyList[Int]): F[Map[Int, String]] = for {
+      _ <- CF.delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids"))
+      _ <- latency(100)
+      _ <- CF.delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids"))
     } yield ids.toList.map(i => (i, i.toString)).toMap
   }
 }
@@ -162,15 +164,16 @@ Note that the `DataSource#batch` method is not mandatory, it will be implemented
 object UnbatchedToString extends Data[Int, String] {
   def name = "Unbatched to string"
 
-  def source[F[_]] = new DataSource[F, Int, String] {
+  def source[F[_] : ConcurrentEffect] = new DataSource[F, Int, String] {
     override def data = UnbatchedToString
 
-    override def fetch(id: Int)(
-      implicit E: ConcurrentEffect[F] 
-    ): F[Option[String]] = 
-      E.delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-      E.delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-      E.pure(Option(id.toString))
+    override def CF = ConcurrentEffect[F]
+
+    override def fetch(id: Int): F[Option[String]] = 
+      CF.delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      latency(100) >>
+      CF.delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      CF.pure(Option(id.toString))
   }
 }
 
@@ -199,22 +202,22 @@ If we combine two independent fetches from different data sources, the fetches c
 object Length extends Data[String, Int] {
   def name = "Length"
 
-  def source[F[_]] = new DataSource[F, String, Int] {
+  def source[F[_] : ConcurrentEffect] = new DataSource[F, String, Int] {
     override def data = Length
 
-    override def fetch(id: String)(
-      implicit E: ConcurrentEffect[F]
-    ): F[Option[Int]] = for {
-      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One Length $id"))
-      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id"))
+    override def CF = ConcurrentEffect[F]
+
+    override def fetch(id: String): F[Option[Int]] = for {
+      _ <- CF.delay(println(s"--> [${Thread.currentThread.getId}] One Length $id"))
+      _ <- latency(100)
+      _ <- CF.delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id"))
     } yield Option(id.size)
 
-      override def batch(ids: NonEmptyList[String])(
-        implicit E: ConcurrentEffect[F]
-      ): F[Map[String, Int]] = for {
-        _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids"))
-        _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids"))
-      } yield ids.toList.map(i => (i, i.size)).toMap
+    override def batch(ids: NonEmptyList[String]): F[Map[String, Int]] = for {
+      _ <- CF.delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids"))
+      _ <- latency(100)
+      _ <- CF.delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids"))
+    } yield ids.toList.map(i => (i, i.size)).toMap
   }
 }
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -56,10 +56,12 @@ Data Sources take two type parameters:
 import cats.data.NonEmptyList
 import cats.effect.ConcurrentEffect
 
-trait DataSource[Identity, Result]{
-  def name: String
-  def fetch[F[_] : ConcurrentEffect](id: Identity): F[Option[Result]]
-  def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Identity]): F[Map[Identity, Result]]
+trait DataSource[F[_], Identity, Result]{
+  def data: Data[Identity, Result]
+  def fetch(id: Identity): F[Option[Result]]
+  def batch(ids: NonEmptyList[Identity])(
+    implicit E: ConcurrentEffect[F]
+  ): F[Map[Identity, Result]]
 }
 ```
 
@@ -68,31 +70,39 @@ Returning `ConcurrentEffect` instances from the fetch methods allows us to speci
 We'll implement a dummy data source that can convert integers to strings. For convenience, we define a `fetchString` function that lifts identities (`Int` in our dummy data source) to a `Fetch`.
 
 ```tut:silent
+import cats._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
+import cats.implicits._
 import cats.syntax.all._
 
 import fetch._
 
-object ToStringSource extends DataSource[Int, String]{
-  override def name = "ToString"
+object ToString extends Data[Int, String] {
+  def name = "To String"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id")) >>
-    Sync[F].pure(Option(id.toString))
-  }
+  def source[F[_] : Monad]: DataSource[F, Int, String] = new DataSource[F, Int, String]{
+    override def data = ToString
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Int]): F[Map[Int, String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids")) >>
-    Sync[F].pure(ids.toList.map(i => (i, i.toString)).toMap)
+    override def fetch(id: Int)(
+      implicit E: ConcurrentEffect[F]
+    ): F[Option[String]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id"))
+    } yield Option(id.toString)
+
+    override def batch(ids: NonEmptyList[Int])(
+      implicit E: ConcurrentEffect[F]
+    ): F[Map[Int, String]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids"))
+    } yield ids.toList.map(i => (i, i.toString)).toMap
   }
 }
 
 def fetchString[F[_] : ConcurrentEffect](n: Int): Fetch[F, String] =
-  Fetch(n, ToStringSource)
+  Fetch(n, ToString.source)
 ```
 
 ## Creating a runtime
@@ -149,18 +159,23 @@ Fetch.run[IO](fetchThree).unsafeRunTimed(5.seconds)
 Note that the `DataSource#batch` method is not mandatory, it will be implemented in terms of `DataSource#fetch` if you don't provide an implementation.
 
 ```tut:silent
-object UnbatchedToStringSource extends DataSource[Int, String]{
-  override def name = "UnbatchedToString"
+object UnbatchedToString extends Data[Int, String] {
+  def name = "Unbatched to string"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-    Sync[F].pure(Option(id.toString))
+  def source[F[_]] = new DataSource[F, Int, String] {
+    override def data = UnbatchedToString
+
+    override def fetch(id: Int)(
+      implicit E: ConcurrentEffect[F] 
+    ): F[Option[String]] = 
+      E.delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      E.delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      E.pure(Option(id.toString))
   }
 }
 
 def unbatchedString[F[_] : ConcurrentEffect](n: Int): Fetch[F, String] =
-  Fetch(n, UnbatchedToStringSource)
+  Fetch(n, UnbatchedToString.source)
 ```
 
 Let's create a tuple of unbatched string requests.
@@ -181,23 +196,30 @@ Fetch.run[IO](fetchUnbatchedThree).unsafeRunTimed(5.seconds)
 If we combine two independent fetches from different data sources, the fetches can be run in parallel. First, let's add a data source that fetches a string's size.
 
 ```tut:silent
-object LengthSource extends DataSource[String, Int]{
-  override def name = "Length"
+object Length extends Data[String, Int] {
+  def name = "Length"
 
-  override def fetch[F[_] : ConcurrentEffect](id: String): F[Option[Int]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One Length $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id")) >>
-    Sync[F].pure(Option(id.size))
-  }
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[String]): F[Map[String, Int]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids")) >>
-    Sync[F].pure(ids.toList.map(i => (i, i.size)).toMap)
+  def source[F[_]] = new DataSource[F, String, Int] {
+    override def data = Length
+
+    override def fetch(id: String)(
+      implicit E: ConcurrentEffect[F]
+    ): F[Option[Int]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One Length $id"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id"))
+    } yield Option(id.size)
+
+      override def batch(ids: NonEmptyList[String])(
+        implicit E: ConcurrentEffect[F]
+      ): F[Map[String, Int]] = for {
+        _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids"))
+        _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids"))
+      } yield ids.toList.map(i => (i, i.size)).toMap
   }
 }
 
 def fetchLength[F[_] : ConcurrentEffect](s: String): Fetch[F, Int] =
-  Fetch(s, LengthSource)
+  Fetch(s, Length.source)
 ```
 
 And now we can easily receive data from the two sources in a single fetch.

--- a/examples/src/test/scala/DoobieExample.scala
+++ b/examples/src/test/scala/DoobieExample.scala
@@ -29,56 +29,13 @@ import scala.concurrent.{ExecutionContext}
 
 import fetch._
 
-class DoobieExample extends WordSpec with Matchers {
-  implicit val executionContext = ExecutionContext.Implicits.global
-
-  implicit val t: Timer[IO]         = IO.timer(executionContext)
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
-
-  val createTransactor: IO[Transactor[IO]] =
-    H2Transactor[IO]("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
-
+object DatabaseExample {
   case class AuthorId(id: Int)
   case class Author(id: Int, name: String)
 
-  val dropTable = sql"DROP TABLE IF EXISTS author".update.run
-
-  val createTable = sql"""
-     CREATE TABLE author (
-       id INTEGER PRIMARY KEY,
-       name VARCHAR(20) NOT NULL UNIQUE
-     )
-    """.update.run
-
-  def addAuthor(author: Author) =
-    sql"INSERT INTO author (id, name) VALUES(${author.id}, ${author.name})".update.run
-
-  val authors: List[Author] =
-    List("William Shakespeare", "Charles Dickens", "George Orwell").zipWithIndex.map {
-      case (name, id) => Author(id + 1, name)
-    }
-
-  val xa: Transactor[IO] =
-    (for {
-      xa <- createTransactor
-      _  <- (dropTable *> createTable *> authors.traverse(addAuthor)).transact(xa)
-    } yield xa).unsafeRunSync()
-
-  val authorDS = new DataSource[AuthorId, Author] {
-    override def name = "AuthorDoobie"
-
-    override def fetch[F[_]: ConcurrentEffect](id: AuthorId): F[Option[Author]] =
-      LiftIO[F].liftIO(fetchById(id).transact(xa))
-
-    override def batch[F[_]: ConcurrentEffect](
-        ids: NonEmptyList[AuthorId]): F[Map[AuthorId, Author]] =
-      LiftIO[F].liftIO(
-        fetchByIds(ids)
-          .map { authors =>
-            authors.map(a => AuthorId(a.id) -> a).toMap
-          }
-          .transact(xa)
-      )
+  object Queries {
+    implicit val authorIdMeta: Meta[AuthorId] =
+      Meta[Int].xmap(AuthorId(_), _.id)
 
     def fetchById(id: AuthorId): ConnectionIO[Option[Author]] =
       sql"SELECT * FROM author WHERE id = $id".query[Author].option
@@ -87,19 +44,73 @@ class DoobieExample extends WordSpec with Matchers {
       val q = fr"SELECT * FROM author WHERE" ++ Fragments.in(fr"id", ids)
       q.query[Author].list
     }
-
-    implicit val authorIdMeta: Meta[AuthorId] =
-      Meta[Int].xmap(AuthorId(_), _.id)
   }
 
-  def author[F[_]: ConcurrentEffect](id: Int): Fetch[F, Author] =
-    Fetch(AuthorId(id), authorDS)
+  object Database {
+    val createTable = sql"""
+       CREATE TABLE author (
+         id INTEGER PRIMARY KEY,
+         name VARCHAR(20) NOT NULL UNIQUE
+       )
+      """.update.run
+
+    val dropTable = sql"DROP TABLE IF EXISTS author".update.run
+
+    def addAuthor(author: Author) =
+      sql"INSERT INTO author (id, name) VALUES(${author.id}, ${author.name})".update.run
+
+    val authors: List[Author] =
+      List("William Shakespeare", "Charles Dickens", "George Orwell").zipWithIndex.map {
+        case (name, id) => Author(id + 1, name)
+      }
+
+    def createTransactor[F[_]: ConcurrentEffect] =
+      H2Transactor[F]("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
+
+    def transactor[F[_]: ConcurrentEffect]: F[Transactor[F]] =
+      for {
+        xa <- createTransactor
+        _  <- (dropTable *> createTable *> authors.traverse(addAuthor)).transact(xa)
+      } yield xa
+  }
+
+  object Authors extends Data[AuthorId, Author] {
+    def name = "Authors"
+
+    def db[F[_]]: DataSource[F, AuthorId, Author] =
+      new DataSource[F, AuthorId, Author] {
+        def data = Authors
+
+        override def fetch(id: AuthorId)(
+            implicit C: ConcurrentEffect[F]
+        ): F[Option[Author]] =
+          Database.transactor
+            .flatMap(Queries.fetchById(id).transact(_))
+
+        override def batch(ids: NonEmptyList[AuthorId])(
+            implicit C: ConcurrentEffect[F]
+        ): F[Map[AuthorId, Author]] =
+          Database.transactor
+            .flatMap(Queries.fetchByIds(ids).transact(_))
+            .map { authors =>
+              authors.map(a => AuthorId(a.id) -> a).toMap
+            }
+      }
+
+    def fetchAuthor[F[_]: ConcurrentEffect](id: Int): Fetch[F, Author] =
+      Fetch(AuthorId(id), Authors.db)
+  }
+}
+
+class DoobieExample extends WordSpec with Matchers {
+  import DatabaseExample._
+
+  val executionContext              = ExecutionContext.Implicits.global
+  implicit val t: Timer[IO]         = IO.timer(executionContext)
+  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   "We can fetch one author from the DB" in {
-    def fetch[F[_]: ConcurrentEffect]: Fetch[F, Author] =
-      author(1)
-
-    val io: IO[(Env, Author)] = Fetch.runEnv[IO](fetch)
+    val io: IO[(Env, Author)] = Fetch.runEnv[IO](Authors.fetchAuthor(1))
 
     val (env, result) = io.unsafeRunSync
 
@@ -109,7 +120,7 @@ class DoobieExample extends WordSpec with Matchers {
 
   "We can fetch multiple authors from the DB in parallel" in {
     def fetch[F[_]: ConcurrentEffect]: Fetch[F, List[Author]] =
-      List(1, 2).traverse(author[F])
+      List(1, 2).traverse(Authors.fetchAuthor[F])
 
     val io: IO[(Env, List[Author])] = Fetch.runEnv[IO](fetch)
 
@@ -122,8 +133,8 @@ class DoobieExample extends WordSpec with Matchers {
   "We can fetch multiple authors from the DB using a for comprehension" in {
     def fetch[F[_]: ConcurrentEffect]: Fetch[F, List[Author]] =
       for {
-        a <- author(1)
-        b <- author(a.id + 1)
+        a <- Authors.fetchAuthor(1)
+        b <- Authors.fetchAuthor(a.id + 1)
       } yield List(a, b)
 
     val io: IO[(Env, List[Author])] = Fetch.runEnv[IO](fetch)

--- a/examples/src/test/scala/JedisExample.scala
+++ b/examples/src/test/scala/JedisExample.scala
@@ -25,8 +25,6 @@ import cats.syntax.all._
 import io.circe._
 import io.circe.generic.semiauto._
 
-import org.http4s.circe._
-import org.http4s.client.blaze._
 import org.scalatest.{Matchers, WordSpec}
 
 import java.io._
@@ -36,71 +34,27 @@ import redis.clients.jedis._
 import fetch._
 
 object DataSources {
-  // the User and Post classes
+  object Numbers extends Data[Int, Int] {
+    def name = "Numbers"
 
-  case class UserId(id: Int)
-  case class PostId(id: Int)
+    def source[F[_]]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
+      def data = Numbers
 
-  case class User(id: UserId, name: String, username: String, email: String)
-  case class Post(id: PostId, userId: UserId, title: String, body: String)
-
-  // some circe decoders
-
-  implicit val userIdDecoder: Decoder[UserId] = Decoder[Int].map(UserId.apply)
-  implicit val postIdDecoder: Decoder[PostId] = Decoder[Int].map(PostId.apply)
-  implicit val userDecoder: Decoder[User]     = deriveDecoder
-  implicit val postDecoder: Decoder[Post]     = deriveDecoder
-
-  // http4s client which is used by the datasources
-
-  def client[F[_]: ConcurrentEffect] =
-    Http1Client[F](
-      BlazeClientConfig.defaultConfig.copy(
-        responseHeaderTimeout = 30.seconds // high timeout because jsonplaceholder takes a while to respond
-      ))
-
-  // a DataSource that can fetch Users with their UserId.
-
-  object Users extends DataSource[UserId, User] {
-    override def name = "UserH4s"
-
-    override def fetch[F[_]: ConcurrentEffect](id: UserId): F[Option[User]] = {
-      val url = s"https://jsonplaceholder.typicode.com/users?id=${id.id}"
-      client[F] >>= ((c) => c.expect(url)(jsonOf[F, List[User]]).map(_.headOption))
-    }
-
-    override def batch[F[_]: ConcurrentEffect](
-        ids: NonEmptyList[UserId]
-    ): F[Map[UserId, User]] = {
-      val filterIds = ids.map("id=" + _.id).toList.mkString("&")
-      val url       = s"https://jsonplaceholder.typicode.com/users?$filterIds"
-      val io        = client[F] >>= ((c) => c.expect(url)(jsonOf[F, List[User]]))
-      io.map(users => users.map(user => user.id -> user).toMap)
+      override def fetch(id: Int)(implicit C: ConcurrentEffect[F]): F[Option[Int]] =
+        C.pure(Option(id))
     }
   }
 
-  // some helper methods to create Fetches
+  def fetchNumber[F[_]: ConcurrentEffect](id: Int): Fetch[F, Int] =
+    Fetch(id, Numbers.source)
 
-  def user[F[_]: ConcurrentEffect](id: UserId): Fetch[F, User] =
-    Fetch(id, Users)
-
-  object Numbers extends DataSource[Int, Int] {
-    override def name = "Numbers"
-
-    override def fetch[F[_]: ConcurrentEffect](id: Int): F[Option[Int]] =
-      Sync[F].pure(Option(id))
-  }
-
-  def number[F[_]: ConcurrentEffect](id: Int): Fetch[F, Int] =
-    Fetch(id, Numbers)
-
-  def fetch[F[_]: ConcurrentEffect]: Fetch[F, User] =
+  def fetch[F[_]: ConcurrentEffect]: Fetch[F, HttpExample.User] =
     for {
-      _ <- user(UserId(1))
-      n <- number(1)
-      _ <- user(UserId(n))
-      _ <- number(n)
-      u <- user(UserId(n))
+      _ <- HttpExample.fetchUser(1)
+      n <- fetchNumber(1)
+      _ <- HttpExample.fetchUser(n)
+      _ <- fetchNumber(n)
+      u <- HttpExample.fetchUser(n)
     } yield u
 }
 
@@ -148,59 +102,58 @@ object Binary {
 
 }
 
+case class RedisCache[F[_]: Sync](host: String) extends DataCache[F] {
+  private val binaryClient = new BinaryJedis(host)
+
+  def client: F[BinaryJedis] =
+    Sync[F].pure(binaryClient)
+
+  private def get(i: Array[Byte]): F[Option[Array[Byte]]] =
+    Sync[F].bracket(client)({ c =>
+      Sync[F].pure(Option(c.get(i)))
+    })({ in =>
+      Sync[F].pure(in.close())
+    })
+
+  private def set(i: Array[Byte], v: Array[Byte]): F[Unit] =
+    Sync[F].bracket(client)({ c =>
+      Sync[F].pure(c.set(i, v)).void
+    })({ in =>
+      Sync[F].pure(in.close())
+    })
+
+  private def identity[I, A](i: I, data: Data[I, A]): Array[Byte] =
+    Binary.fromString(s"${data.identity} ${i}")
+
+  def lookup[I, A](i: I, data: Data[I, A]): F[Option[A]] =
+    get(identity(i, data)) >>= { case (raw) => Binary.deserialize(raw) }
+
+  def insert[I, A](i: I, v: A, data: Data[I, A]): F[DataCache[F]] =
+    for {
+      s <- Binary.serialize(v)
+      _ <- set(identity(i, data), s)
+    } yield this
+}
+
 class JedisExample extends WordSpec with Matchers {
   import DataSources._
 
-  case class RedisCache[F[_]: Sync](host: String) extends DataSourceCache[F] {
-    private val binaryClient = new BinaryJedis(host)
-
-    def client: F[BinaryJedis] =
-      Sync[F].pure(binaryClient)
-
-    private def get(i: Array[Byte]): F[Option[Array[Byte]]] =
-      Sync[F].bracket(client)({ c =>
-        Sync[F].pure(Option(c.get(i)))
-      })({ in =>
-        Sync[F].pure(in.close())
-      })
-
-    private def set(i: Array[Byte], v: Array[Byte]): F[Unit] =
-      Sync[F].bracket(client)({ c =>
-        Sync[F].pure(c.set(i, v)).void
-      })({ in =>
-        Sync[F].pure(in.close())
-      })
-
-    private def identity[I, A](i: I, ds: DataSource[I, A]): Array[Byte] =
-      Binary.fromString(s"${ds.name} ${i}")
-
-    def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]] =
-      get(identity(i, ds)) >>= { case (raw) => Binary.deserialize(raw) }
-
-    def insert[I, A](i: I, v: A, ds: DataSource[I, A]): F[DataSourceCache[F]] =
-      for {
-        s <- Binary.serialize(v)
-        _ <- set(identity(i, ds), s)
-      } yield this
-  }
-
   // runtime
-
   val executionContext              = ExecutionContext.Implicits.global
   implicit val t: Timer[IO]         = IO.timer(executionContext)
   implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
 
   "We can use a Redis cache" in {
-    val cache               = RedisCache[IO]("localhost")
-    val io: IO[(Env, User)] = Fetch.runEnv[IO](fetch, cache)
+    val cache                           = RedisCache[IO]("localhost")
+    val io: IO[(Env, HttpExample.User)] = Fetch.runEnv[IO](fetch, cache)
 
     val (env, result) = io.unsafeRunSync
 
     println(result)
     env.rounds.size shouldEqual 2
 
-    val io2: IO[(Env, User)] = Fetch.runEnv[IO](fetch, cache)
-    val (env2, result2)      = io2.unsafeRunSync
+    val io2: IO[(Env, HttpExample.User)] = Fetch.runEnv[IO](fetch, cache)
+    val (env2, result2)                  = io2.unsafeRunSync
 
     println(result2)
     env2.rounds.size shouldEqual 0

--- a/examples/src/test/scala/JedisExample.scala
+++ b/examples/src/test/scala/JedisExample.scala
@@ -37,11 +37,13 @@ object DataSources {
   object Numbers extends Data[Int, Int] {
     def name = "Numbers"
 
-    def source[F[_]]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
+    def source[F[_]: ConcurrentEffect]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
       def data = Numbers
 
-      override def fetch(id: Int)(implicit C: ConcurrentEffect[F]): F[Option[Int]] =
-        C.pure(Option(id))
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: Int): F[Option[Int]] =
+        CF.pure(Option(id))
     }
   }
 

--- a/shared/src/main/scala/cache.scala
+++ b/shared/src/main/scala/cache.scala
@@ -22,26 +22,23 @@ import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.syntax.all._
 
-final class DataSourceName(val name: String) extends AnyVal
 final class DataSourceId(val id: Any) extends AnyVal
 final class DataSourceResult(val result: Any) extends AnyVal
 
 /**
  * A `Cache` trait so the users of the library can provide their own cache.
  */
-trait DataSourceCache[F[_]] {
-  def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]]
+trait DataCache[F[_]] {
+  def lookup[I, A](i: I, data: Data[I, A]): F[Option[A]]
 
-  def insert[I, A](i: I, v: A, ds: DataSource[I, A]): F[DataSourceCache[F]]
+  def insert[I, A](i: I, v: A, data: Data[I, A]): F[DataCache[F]]
 
-  // def delete[I, A](i: I, v: A, ds: DataSource[I, A]): F[Unit]
-
-  def bulkInsert[I, A](vs: List[(I, A)], ds: DataSource[I, A])(
+  def bulkInsert[I, A](vs: List[(I, A)], data: Data[I, A])(
     implicit M: Monad[F]
-  ): F[DataSourceCache[F]] = {
+  ): F[DataCache[F]] = {
     vs.foldLeftM(this){
       case (acc, (i, v)) =>
-        acc.insert(i, v, ds)
+        acc.insert(i, v, data)
     }
   }
 }
@@ -49,19 +46,22 @@ trait DataSourceCache[F[_]] {
 /**
  * A cache that stores its elements in memory.
  */
-case class InMemoryCache[F[_] : Monad](state: Map[(DataSourceName, DataSourceId), DataSourceResult]) extends DataSourceCache[F] {
-  def lookup[I, A](i: I, ds: DataSource[I, A]): F[Option[A]] =
-    Applicative[F].pure(state.get((new DataSourceName(ds.name), new DataSourceId(i))).map(_.result.asInstanceOf[A]))
+case class InMemoryCache[F[_] : Monad](state: Map[(Data[Any, Any], DataSourceId), DataSourceResult]) extends DataCache[F] {
+  def lookup[I, A](i: I, data: Data[I, A]): F[Option[A]] =
+    Applicative[F].pure(
+      state.get(
+        (data.asInstanceOf[Data[Any, Any]], new DataSourceId(i))).map(_.result.asInstanceOf[A]))
 
-  def insert[I, A](i: I, v: A, ds: DataSource[I, A]): F[DataSourceCache[F]] =
-    Applicative[F].pure(copy(state = state.updated((new DataSourceName(ds.name), new DataSourceId(i)), new DataSourceResult(v))))
+  def insert[I, A](i: I, v: A, data: Data[I, A]): F[DataCache[F]] =
+    Applicative[F].pure(
+      copy(state = state.updated((data.asInstanceOf[Data[Any, Any]], new DataSourceId(i)), new DataSourceResult(v))))
 }
 
 object InMemoryCache {
-  def empty[F[_] : Monad]: InMemoryCache[F] = InMemoryCache[F](Map.empty[(DataSourceName, DataSourceId), DataSourceResult])
+  def empty[F[_] : Monad]: InMemoryCache[F] = InMemoryCache[F](Map.empty[(Data[Any, Any], DataSourceId), DataSourceResult])
 
-  def from[F[_]: Monad, I, A](results: ((String, I), A)*): InMemoryCache[F] =
-    InMemoryCache[F](results.foldLeft(Map.empty[(DataSourceName, DataSourceId), DataSourceResult])({
-      case (acc, ((s, i), v)) => acc.updated((new DataSourceName(s), new DataSourceId(i)), new DataSourceResult(v))
+  def from[F[_]: Monad, I, A](results: ((Data[I, A], I), A)*): InMemoryCache[F] =
+    InMemoryCache[F](results.foldLeft(Map.empty[(Data[Any, Any], DataSourceId), DataSourceResult])({
+      case (acc, ((data, i), v)) => acc.updated((data.asInstanceOf[Data[Any, Any]], new DataSourceId(i)), new DataSourceResult(v))
     }))
 }

--- a/shared/src/main/scala/datasource.scala
+++ b/shared/src/main/scala/datasource.scala
@@ -45,14 +45,16 @@ object Data {
 trait DataSource[F[_], I, A] {
   def data: Data[I, A]
 
+  implicit def CF: ConcurrentEffect[F]
+
   /** Fetch one identity, returning a None if it wasn't found.
    */
-  def fetch(id: I)(implicit C: ConcurrentEffect[F]): F[Option[A]]
+  def fetch(id: I): F[Option[A]]
 
   /** Fetch many identities, returning a mapping from identities to results. If an
    * identity wasn't found, it won't appear in the keys.
    */
-  def batch(ids: NonEmptyList[I])(implicit C: ConcurrentEffect[F]): F[Map[I, A]] =
+  def batch(ids: NonEmptyList[I]): F[Map[I, A]] =
     FetchExecution.parallel(
       ids.map(id => fetch(id).map((v) => id -> v))
     ).map(_.collect({ case (id, Some(x)) => id -> x }).toMap)

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -137,8 +137,8 @@ object `package` {
           val combined = acc.get(dsId).fold(
             (ds, blocked)
           )({
-            case (ds, req) => {
-              (ds, combineRequests(blocked, req))
+            case (d, req) => {
+              (d, combineRequests(blocked, req))
             }
           })
           acc.updated(dsId, combined)

--- a/shared/src/test/scala/FetchAsyncQueryTests.scala
+++ b/shared/src/test/scala/FetchAsyncQueryTests.scala
@@ -90,11 +90,11 @@ object DataSources {
     def name = "Articles"
 
     implicit def async[F[_] : ConcurrentEffect]: DataSource[F, ArticleId, Article] = new DataSource[F, ArticleId, Article] {
+      override def CF = ConcurrentEffect[F]
+
       override def data = Article 
 
-      override def fetch(id: ArticleId)(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Option[Article]] =
+      override def fetch(id: ArticleId): F[Option[Article]] =
         CF.async[Option[Article]]((cb) => {
           cb(
             Right(
@@ -115,11 +115,11 @@ object DataSources {
     def name = "Authors"
 
     implicit def async[F[_] : ConcurrentEffect]: DataSource[F, AuthorId, Author] = new DataSource[F, AuthorId, Author]  {
+      override def CF = ConcurrentEffect[F]
+
       override def data = Author
 
-      override def fetch(id: AuthorId)(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Option[Author]] =
+      override def fetch(id: AuthorId): F[Option[Author]] =
         CF.async((cb => {
           cb(
             Right(

--- a/shared/src/test/scala/FetchBatchingTests.scala
+++ b/shared/src/test/scala/FetchBatchingTests.scala
@@ -35,9 +35,9 @@ class FetchBatchingTests extends FetchSpec {
     implicit def source[F[_] : ConcurrentEffect]: DataSource[F, BatchedDataSeq, Int] = new DataSource[F, BatchedDataSeq, Int] {
       override def data = SeqBatch
 
-      override def fetch(id: BatchedDataSeq)(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Option[Int]] =
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: BatchedDataSeq): F[Option[Int]] =
         CF.pure(Some(id.id))
 
       override val maxBatchSize = Some(2)
@@ -54,9 +54,9 @@ class FetchBatchingTests extends FetchSpec {
     implicit def source[F[_] : ConcurrentEffect]: DataSource[F, BatchedDataPar, Int] = new DataSource[F, BatchedDataPar, Int] {
       override def data = ParBatch
 
-      override def fetch(id: BatchedDataPar)(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Option[Int]] =
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: BatchedDataPar): F[Option[Int]] =
         CF.pure(Some(id.id))
 
       override val maxBatchSize = Some(2)

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -794,9 +794,9 @@ class FetchTests extends FetchSpec {
     implicit def source[F[_] : ConcurrentEffect] = new DataSource[F, MaybeMissing, Int] {
       override def data = MaybeMissing
 
-      override def fetch(id: MaybeMissing)(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Option[Int]] =
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: MaybeMissing): F[Option[Int]] =
         if (id.id % 2 == 0)
           CF.pure(None)
         else

--- a/shared/src/test/scala/TestHelper.scala
+++ b/shared/src/test/scala/TestHelper.scala
@@ -26,66 +26,76 @@ import scala.collection.immutable.Map
 object TestHelper {
   case class AnException() extends Throwable
 
-  case class One(id: Int)
+  object One extends Data[Int, Int] {
+    def name = "One"
 
-  object OneSource extends DataSource[One, Int] {
-    override def name = "OneSource"
+    def source[F[_] : ConcurrentEffect]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
+      override def data = One
 
-    override def fetch[F[_]](id: One)(
-      implicit CF: ConcurrentEffect[F]
-    ): F[Option[Int]] =
-      Applicative[F].pure(Option(id.id))
+      override def fetch(id: Int)(
+        implicit CF: ConcurrentEffect[F]
+      ): F[Option[Int]] =
+        CF.pure(Option(id))
 
-    override def batch[F[_]](ids: NonEmptyList[One])(
-      implicit CF: ConcurrentEffect[F]
-    ): F[Map[One, Int]] =
-      Applicative[F].pure(
-        ids.toList.map((v) => (v, v.id)).toMap
-      )
+      override def batch(ids: NonEmptyList[Int])(
+        implicit CF: ConcurrentEffect[F]
+      ): F[Map[Int, Int]] =
+        CF.pure(
+          ids.toList.map((v) => (v, v)).toMap
+        )
+    }
   }
 
   def one[F[_] : ConcurrentEffect](id: Int): Fetch[F, Int] =
-    Fetch(One(id), OneSource)
+    Fetch(id, One.source)
 
-  case class Many(n: Int)
+  object Many extends Data[Int, List[Int]] {
+    def name = "Many"
 
-  object ManySource extends DataSource[Many, List[Int]] {
-    override def name = "ManySource"
+    def source[F[_] : ConcurrentEffect]: DataSource[F, Int, List[Int]] = new DataSource[F, Int, List[Int]] {
+      override def data = Many
 
-    override def fetch[F[_] : ConcurrentEffect](id: Many): F[Option[List[Int]]] =
-      Applicative[F].pure(Option(0 until id.n toList))
+      override def fetch(id: Int)(implicit C: ConcurrentEffect[F]): F[Option[List[Int]]] =
+        C.pure(Option(0 until id toList))
+    }
   }
 
   def many[F[_] : ConcurrentEffect](id: Int): Fetch[F, List[Int]] =
-    Fetch(Many(id), ManySource)
+    Fetch(id, Many.source)
 
-  case class AnotherOne(id: Int)
+  object AnotherOne extends Data[Int, Int] {
+    def name = "Another one"
 
-  object AnotheroneSource extends DataSource[AnotherOne, Int] {
-    override def name = "AnotherOneSource"
+    def source[F[_] : ConcurrentEffect]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
+      override def data = AnotherOne
 
-    override def fetch[F[_] : ConcurrentEffect](id: AnotherOne): F[Option[Int]] =
-      Applicative[F].pure(Option(id.id))
+      override def fetch(id: Int)(implicit C: ConcurrentEffect[F]): F[Option[Int]] =
+        C.pure(Option(id))
 
-    override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[AnotherOne]): F[Map[AnotherOne, Int]] =
-      Applicative[F].pure(
-        ids.toList.map((v) => (v, v.id)).toMap
-      )
+      override def batch(ids: NonEmptyList[Int])(implicit C: ConcurrentEffect[F]): F[Map[Int, Int]] =
+        C.pure(
+          ids.toList.map((v) => (v, v)).toMap
+        )
+    }
   }
 
   def anotherOne[F[_] : ConcurrentEffect](id: Int): Fetch[F, Int] =
-    Fetch(AnotherOne(id), AnotheroneSource)
+    Fetch(id, AnotherOne.source)
 
   case class Never()
 
-  object NeverSource extends DataSource[Never, Int] {
-    override def name = "NeverSource"
+  object Never extends Data[Never, Int] {
+    def name = "Never"
 
-    override def fetch[F[_] : ConcurrentEffect](id: Never): F[Option[Int]] =
-      Applicative[F].pure(None : Option[Int])
+    def source[F[_] : ConcurrentEffect]: DataSource[F, Never, Int] = new DataSource[F, Never, Int] {
+      override def data = Never
+
+      override def fetch(id: Never)(implicit C: ConcurrentEffect[F]): F[Option[Int]] =
+        C.pure(None : Option[Int])
+    }
   }
 
   def never[F[_] : ConcurrentEffect]: Fetch[F, Int] =
-    Fetch(Never(), NeverSource)
+    Fetch(Never(), Never.source)
 
 }

--- a/shared/src/test/scala/TestHelper.scala
+++ b/shared/src/test/scala/TestHelper.scala
@@ -32,14 +32,12 @@ object TestHelper {
     def source[F[_] : ConcurrentEffect]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
       override def data = One
 
-      override def fetch(id: Int)(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Option[Int]] =
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: Int): F[Option[Int]] =
         CF.pure(Option(id))
 
-      override def batch(ids: NonEmptyList[Int])(
-        implicit CF: ConcurrentEffect[F]
-      ): F[Map[Int, Int]] =
+      override def batch(ids: NonEmptyList[Int]): F[Map[Int, Int]] =
         CF.pure(
           ids.toList.map((v) => (v, v)).toMap
         )
@@ -55,8 +53,10 @@ object TestHelper {
     def source[F[_] : ConcurrentEffect]: DataSource[F, Int, List[Int]] = new DataSource[F, Int, List[Int]] {
       override def data = Many
 
-      override def fetch(id: Int)(implicit C: ConcurrentEffect[F]): F[Option[List[Int]]] =
-        C.pure(Option(0 until id toList))
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: Int): F[Option[List[Int]]] =
+        CF.pure(Option(0 until id toList))
     }
   }
 
@@ -69,11 +69,13 @@ object TestHelper {
     def source[F[_] : ConcurrentEffect]: DataSource[F, Int, Int] = new DataSource[F, Int, Int] {
       override def data = AnotherOne
 
-      override def fetch(id: Int)(implicit C: ConcurrentEffect[F]): F[Option[Int]] =
-        C.pure(Option(id))
+      override def CF = ConcurrentEffect[F]
 
-      override def batch(ids: NonEmptyList[Int])(implicit C: ConcurrentEffect[F]): F[Map[Int, Int]] =
-        C.pure(
+      override def fetch(id: Int): F[Option[Int]] =
+        CF.pure(Option(id))
+
+      override def batch(ids: NonEmptyList[Int]): F[Map[Int, Int]] =
+        CF.pure(
           ids.toList.map((v) => (v, v)).toMap
         )
     }
@@ -90,8 +92,10 @@ object TestHelper {
     def source[F[_] : ConcurrentEffect]: DataSource[F, Never, Int] = new DataSource[F, Never, Int] {
       override def data = Never
 
-      override def fetch(id: Never)(implicit C: ConcurrentEffect[F]): F[Option[Int]] =
-        C.pure(None : Option[Int])
+      override def CF = ConcurrentEffect[F]
+
+      override def fetch(id: Never): F[Option[Int]] =
+        CF.pure(None : Option[Int])
     }
   }
 

--- a/tut/README.md
+++ b/tut/README.md
@@ -60,10 +60,12 @@ Data Sources take two type parameters:
 import cats.data.NonEmptyList
 import cats.effect.ConcurrentEffect
 
-trait DataSource[Identity, Result]{
-  def name: String
-  def fetch[F[_] : ConcurrentEffect](id: Identity): F[Option[Result]]
-  def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Identity]): F[Map[Identity, Result]]
+trait DataSource[F[_], Identity, Result]{
+  def data: Data[Identity, Result]
+  def fetch(id: Identity): F[Option[Result]]
+  def batch(ids: NonEmptyList[Identity])(
+    implicit E: ConcurrentEffect[F]
+  ): F[Map[Identity, Result]]
 }
 ```
 
@@ -72,31 +74,39 @@ Returning `ConcurrentEffect` instances from the fetch methods allows us to speci
 We'll implement a dummy data source that can convert integers to strings. For convenience, we define a `fetchString` function that lifts identities (`Int` in our dummy data source) to a `Fetch`.
 
 ```tut:silent
+import cats._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
+import cats.implicits._
 import cats.syntax.all._
 
 import fetch._
 
-object ToStringSource extends DataSource[Int, String]{
-  override def name = "ToString"
+object ToString extends Data[Int, String] {
+  def name = "To String"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id")) >>
-    Sync[F].pure(Option(id.toString))
-  }
+  def source[F[_] : Monad]: DataSource[F, Int, String] = new DataSource[F, Int, String]{
+    override def data = ToString
 
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[Int]): F[Map[Int, String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids")) >>
-    Sync[F].pure(ids.toList.map(i => (i, i.toString)).toMap)
+    override def fetch(id: Int)(
+      implicit E: ConcurrentEffect[F]
+    ): F[Option[String]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One ToString $id"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One ToString $id"))
+    } yield Option(id.toString)
+
+    override def batch(ids: NonEmptyList[Int])(
+      implicit E: ConcurrentEffect[F]
+    ): F[Map[Int, String]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch ToString $ids"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch ToString $ids"))
+    } yield ids.toList.map(i => (i, i.toString)).toMap
   }
 }
 
 def fetchString[F[_] : ConcurrentEffect](n: Int): Fetch[F, String] =
-  Fetch(n, ToStringSource)
+  Fetch(n, ToString.source)
 ```
 
 ## Creating a runtime
@@ -153,18 +163,23 @@ Fetch.run[IO](fetchThree).unsafeRunTimed(5.seconds)
 Note that the `DataSource#batch` method is not mandatory, it will be implemented in terms of `DataSource#fetch` if you don't provide an implementation.
 
 ```tut:silent
-object UnbatchedToStringSource extends DataSource[Int, String]{
-  override def name = "UnbatchedToString"
+object UnbatchedToString extends Data[Int, String] {
+  def name = "Unbatched to string"
 
-  override def fetch[F[_] : ConcurrentEffect](id: Int): F[Option[String]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
-    Sync[F].pure(Option(id.toString))
+  def source[F[_]] = new DataSource[F, Int, String] {
+    override def data = UnbatchedToString
+
+    override def fetch(id: Int)(
+      implicit E: ConcurrentEffect[F] 
+    ): F[Option[String]] = 
+      E.delay(println(s"--> [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      E.delay(println(s"<-- [${Thread.currentThread.getId}] One UnbatchedToString $id")) >>
+      E.pure(Option(id.toString))
   }
 }
 
 def unbatchedString[F[_] : ConcurrentEffect](n: Int): Fetch[F, String] =
-  Fetch(n, UnbatchedToStringSource)
+  Fetch(n, UnbatchedToString.source)
 ```
 
 Let's create a tuple of unbatched string requests.
@@ -185,23 +200,30 @@ Fetch.run[IO](fetchUnbatchedThree).unsafeRunTimed(5.seconds)
 If we combine two independent fetches from different data sources, the fetches can be run in parallel. First, let's add a data source that fetches a string's size.
 
 ```tut:silent
-object LengthSource extends DataSource[String, Int]{
-  override def name = "Length"
+object Length extends Data[String, Int] {
+  def name = "Length"
 
-  override def fetch[F[_] : ConcurrentEffect](id: String): F[Option[Int]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] One Length $id")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id")) >>
-    Sync[F].pure(Option(id.size))
-  }
-  override def batch[F[_] : ConcurrentEffect](ids: NonEmptyList[String]): F[Map[String, Int]] = {
-    Sync[F].delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids")) >>
-    Sync[F].delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids")) >>
-    Sync[F].pure(ids.toList.map(i => (i, i.size)).toMap)
+  def source[F[_]] = new DataSource[F, String, Int] {
+    override def data = Length
+
+    override def fetch(id: String)(
+      implicit E: ConcurrentEffect[F]
+    ): F[Option[Int]] = for {
+      _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] One Length $id"))
+      _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] One Length $id"))
+    } yield Option(id.size)
+
+      override def batch(ids: NonEmptyList[String])(
+        implicit E: ConcurrentEffect[F]
+      ): F[Map[String, Int]] = for {
+        _ <- E.delay(println(s"--> [${Thread.currentThread.getId}] Batch Length $ids"))
+        _ <- E.delay(println(s"<-- [${Thread.currentThread.getId}] Batch Length $ids"))
+      } yield ids.toList.map(i => (i, i.size)).toMap
   }
 }
 
 def fetchLength[F[_] : ConcurrentEffect](s: String): Fetch[F, Int] =
-  Fetch(s, LengthSource)
+  Fetch(s, Length.source)
 ```
 
 And now we can easily receive data from the two sources in a single fetch.
@@ -243,7 +265,6 @@ executor.shutdownNow()
 ---
 
 For more in-depth information take a look at our [documentation](http://47deg.github.io/fetch/docs.html).
-
 
 ## Fetch in the wild
 


### PR DESCRIPTION
In the old version of Fetch, one needed to define the data source as an
implicit object. This way, we ensured that each DataSource had only one instance using reference equality.

A data source used to look like the following:

```scala
implicit object Users extends DataSource[UserId, User]{
  // ...
}
```

Now that we've introduced an `F[_]` type parameter in `DataSource` we no
longer can define it as an `object`. Thus, we need a way to identify
requests to a data source to be able to perform optimizations.

Now there's a new trait called `Data`, that identifies requests for a
particular piece of data, and is used to identify and group requests for
the same data.

A `Data` definition looks like the following:

```scala
object Users extends Data[Int, User] {
  def name = "Users"
}
```

Then, when defining the data source for users, we have to specify which
`Data` the `DataSource` is fetching:

```scala
def usersSource[F[_] : ConcurrentEffect]: DataSource[F, Int, User] = new DataSource[F, Int,
User] {
  def data = Users

  def CF = ConcurrentEffect[F]

  // ...
}
```

Now that we have `Data` and `DataSource` we can create a `Fetch` por a `User`:

```scala
def fetchUser[F[_] : ConcurrentEffect](id: Int): Fetch[F, User] =
  Fetch(id, usersSource)
```

See the `examples` directory and the tests for plenty of examples.