### PR TITLE
Don't run 'gem update --system'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
 
 install:
 - rvm use 2.3.0 --install --fuzzy
-- gem update --system
 - gem install sass
 - gem install jekyll -v 3.2.1
 


### PR DESCRIPTION
Fixes Travis CI builds that are failing due to an incompatibility between the latest Rubygems and the version of Ruby we use for generating de docs. I believe we use that version of Ruby because of Jekyll, and there is no need to update Rubygems for installing `sass` and `jekyll`.