### PR TITLE
Loosen cats-effect constraints

### DIFF
--- a/examples/src/test/scala/DoobieExample.scala
+++ b/examples/src/test/scala/DoobieExample.scala
@@ -42,7 +42,7 @@ object DatabaseExample {
 
     def fetchByIds(ids: NonEmptyList[AuthorId]): ConnectionIO[List[Author]] = {
       val q = fr"SELECT * FROM author WHERE" ++ Fragments.in(fr"id", ids)
-      q.query[Author].list
+      q.query[Author].to[List]
     }
   }
 
@@ -65,7 +65,7 @@ object DatabaseExample {
       }
 
     def createTransactor[F[_]: ConcurrentEffect] =
-      H2Transactor[F]("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
+      H2Transactor.newH2Transactor[F]("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
 
     def transactor[F[_]: ConcurrentEffect]: F[Transactor[F]] =
       for {

--- a/examples/src/test/scala/MonixExample.scala
+++ b/examples/src/test/scala/MonixExample.scala
@@ -30,7 +30,6 @@ class MonixExample extends AsyncFreeSpec with Matchers {
   implicit val scheduler: Scheduler               = Scheduler.io(name = "test-scheduler")
   override val executionContext: ExecutionContext = scheduler
   implicit val t: Timer[Task]                     = scheduler.timer
-  implicit val cs: ContextShift[Task]             = scheduler.contextShift
 
   import DatabaseExample._
 

--- a/shared/src/main/scala/execution.scala
+++ b/shared/src/main/scala/execution.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 
 private object FetchExecution {
   def parallel[F[_], A](effects: NonEmptyList[F[A]])(
-    implicit CF: ConcurrentEffect[F]
+    implicit CF: Concurrent[F]
   ): F[NonEmptyList[A]] =
     effects.traverse(CF.start(_)).flatMap(fibers =>
       fibers.traverse(_.join).onError({ case _ => fibers.traverse_(_.cancel) })

--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -254,16 +254,16 @@ object `package` {
     /**
      * Lift a plain value to the Fetch monad.
      */
-    def pure[F[_]: ConcurrentEffect, A](a: A): Fetch[F, A] =
+    def pure[F[_]: Concurrent, A](a: A): Fetch[F, A] =
       Unfetch(Applicative[F].pure(Done(a)))
 
-    def exception[F[_]: ConcurrentEffect, A](e: Log => FetchException): Fetch[F, A] =
+    def exception[F[_]: Concurrent, A](e: Log => FetchException): Fetch[F, A] =
       Unfetch(Applicative[F].pure(Throw[F, A](e)))
 
-    def error[F[_]: ConcurrentEffect, A](e: Throwable): Fetch[F, A] =
+    def error[F[_]: Concurrent, A](e: Throwable): Fetch[F, A] =
       exception((log) => UnhandledException(e, log))
 
-    def apply[F[_] : ConcurrentEffect, I, A](
+    def apply[F[_]: Concurrent, I, A](
       id: I,
       ds: DataSource[F, I, A]
     ): Fetch[F, A] =
@@ -277,15 +277,15 @@ object `package` {
           blockedRequest = RequestMap(Map(ds.data.identity -> (anyDs, blocked)))
         } yield Blocked(blockedRequest, Unfetch[F, A](
           deferred.get.map {
-            case FetchDone(a) =>
-              Done(a).asInstanceOf[FetchResult[F, A]]
+            case FetchDone(a: A) =>
+              Done(a)
             case FetchMissing() =>
-              Throw((log) => MissingIdentity(id, request.asInstanceOf[FetchQuery[I, A]], log))
+              Throw(log => MissingIdentity(id, request, log))
           }
         ))
       )
 
-    def optional[F[_] : ConcurrentEffect, I, A](
+    def optional[F[_] : Concurrent, I, A](
       id: I,
       ds: DataSource[F, I, A]
     ): Fetch[F, Option[A]] =
@@ -319,7 +319,7 @@ object `package` {
         fa: Fetch[F, A]
       )(
         implicit
-          C: ConcurrentEffect[F],
+          C: Concurrent[F],
           CS: ContextShift[F],
           T: Timer[F]
       ): F[A] =
@@ -330,7 +330,7 @@ object `package` {
         cache: DataCache[F]
       )(
         implicit
-          C: ConcurrentEffect[F],
+          C: Concurrent[F],
           CS: ContextShift[F],
           T: Timer[F]
       ): F[A] = for {
@@ -349,7 +349,7 @@ object `package` {
         fa: Fetch[F, A]
       )(
         implicit
-          C: ConcurrentEffect[F],
+          C: Concurrent[F],
           CS: ContextShift[F],
           T: Timer[F]
       ): F[(Log, A)] =
@@ -360,7 +360,7 @@ object `package` {
         cache: DataCache[F]
       )(
         implicit
-          C: ConcurrentEffect[F],
+          C: Concurrent[F],
           CS: ContextShift[F],
           T: Timer[F]
       ): F[(Log, A)] = for {
@@ -381,7 +381,7 @@ object `package` {
         fa: Fetch[F, A]
       )(
         implicit
-          C: ConcurrentEffect[F],
+          C: Concurrent[F],
           CS: ContextShift[F],
           T: Timer[F]
       ): F[(DataCache[F], A)] =
@@ -392,7 +392,7 @@ object `package` {
         cache: DataCache[F]
       )(
         implicit
-          C: ConcurrentEffect[F],
+          C: Concurrent[F],
           CS: ContextShift[F],
           T: Timer[F]
       ): F[(DataCache[F], A)] = for {
@@ -410,7 +410,7 @@ object `package` {
       log: Option[Ref[F, Log]]
     )(
       implicit
-        C: ConcurrentEffect[F],
+        C: Concurrent[F],
         CS: ContextShift[F],
         T: Timer[F]
     ): F[A] = for {
@@ -437,7 +437,7 @@ object `package` {
       log: Option[Ref[F, Log]]
     )(
       implicit
-        C: ConcurrentEffect[F],
+        C: Concurrent[F],
         CS: ContextShift[F],
         T: Timer[F]
     ): F[Unit] = {
@@ -464,7 +464,7 @@ object `package` {
       log: Option[Ref[F, Log]]
     )(
       implicit
-        C: ConcurrentEffect[F],
+        C: Concurrent[F],
         CS: ContextShift[F],
         T: Timer[F]
     ): F[List[Request]] =
@@ -482,7 +482,7 @@ object `package` {
     log: Option[Ref[F, Log]]
   )(
     implicit
-      C: ConcurrentEffect[F],
+      C: Concurrent[F],
       CS: ContextShift[F],
       T: Timer[F]
   ): F[List[Request]] =
@@ -527,7 +527,7 @@ object `package` {
     log: Option[Ref[F, Log]]
   )(
     implicit
-      C: ConcurrentEffect[F],
+      C: Concurrent[F],
       CS: ContextShift[F],
       T: Timer[F]
   ): F[List[Request]] =
@@ -581,7 +581,7 @@ object `package` {
     e: BatchExecution
   )(
     implicit
-      C: ConcurrentEffect[F],
+      C: Concurrent[F],
       CS: ContextShift[F],
       T: Timer[F]
   ): F[BatchedRequest] = {

--- a/shared/src/main/scala/syntax.scala
+++ b/shared/src/main/scala/syntax.scala
@@ -24,14 +24,14 @@ object syntax {
   /** Implicit syntax to lift any value to the context of Fetch via pure */
   implicit class FetchIdSyntax[A](val a: A) extends AnyVal {
 
-    def fetch[F[_] : ConcurrentEffect]: Fetch[F, A] =
+    def fetch[F[_] : Concurrent]: Fetch[F, A] =
       Fetch.pure[F, A](a)
   }
 
   /** Implicit syntax to lift exception to Fetch errors */
   implicit class FetchExceptionSyntax[B](val a: Throwable) extends AnyVal {
 
-    def fetch[F[_] : ConcurrentEffect]: Fetch[F, B] =
+    def fetch[F[_] : Concurrent]: Fetch[F, B] =
       Fetch.error[F, B](a)
   }
 }

--- a/shared/src/test/scala/FetchTests.scala
+++ b/shared/src/test/scala/FetchTests.scala
@@ -837,7 +837,7 @@ class FetchTests extends FetchSpec {
   "We can make fetches that depend on optional fetch results when they aren't defined" in {
     def fetch[F[_] : ConcurrentEffect]: Fetch[F, Int] = for {
       maybe <- maybeOpt(2)
-      result <- maybe.fold(Fetch.pure(42))(i => one(i))
+      result <- maybe.fold(Fetch.pure[F, Int](42))(i => one(i))
     } yield result
 
     Fetch.run[IO](fetch).map(_ shouldEqual 42).unsafeToFuture
@@ -846,7 +846,7 @@ class FetchTests extends FetchSpec {
   "We can make fetches that depend on optional fetch results when they are defined" in {
     def fetch[F[_] : ConcurrentEffect]: Fetch[F, Int] = for {
       maybe <- maybeOpt(1)
-      result <- maybe.fold(Fetch.pure(42))(i => one(i))
+      result <- maybe.fold(Fetch.pure[F, Int](42))(i => one(i))
     } yield result
 
     Fetch.run[IO](fetch).map(_ shouldEqual 1).unsafeToFuture


### PR DESCRIPTION
Touches #163 a bit. ConcurrentEffect replaced with Concurrent, ContextShift removed.

Let me know what you think about: replacing Timer usage with Clock (a Clock is implicitly available if a Timer is)