### PR TITLE
Don't run examples tests every time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
 - sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
-- sbt 'examples/test'
+- sbt 'examples/test:compile'
 
 jobs:
   include:


### PR DESCRIPTION
Since they rely on network services that are unreliable and rate limited I think it's best if we just make sure the examples compile. We could run them in the `deploy` job, thoughts?