### PR TITLE
Switch to Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+[member of the project](AUTHORS.md#maintainers).
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Discussion around Fetch happens in the [Gitter channel](https://gitter.im/47deg/
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about
 the code. Pull requests are also welcome.
 
-People are expected to follow the [Typelevel Code of Conduct](http://typelevel.org/conduct.html) when discussing Fetch on the Github page, Gitter channel, or other venues.
+People are expected to follow the [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) when discussing Fetch on the Github page, Gitter channel, or other venues.
 
 If you are being harassed, please contact one of [us](AUTHORS.md#maintainers) immediately so that we can support you. In case you cannot get in touch with us please write an email to [47 Degrees](mailto:hello@47deg.com).
 


### PR DESCRIPTION
Typelevel is [switching to the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and is encouraging all member projects to switch with us.