### PR TITLE
Upgrades sbt-org-policies

### DIFF
--- a/examples/src/test/scala/MonixExample.scala
+++ b/examples/src/test/scala/MonixExample.scala
@@ -34,7 +34,7 @@ class MonixExample extends AsyncFreeSpec with Matchers {
   import DatabaseExample._
 
   "We can run a Fetch into a Monix Task" in {
-    def fetch[F[_]: ConcurrentEffect]: Fetch[F, Author] =
+    def fetch[F[_]: ConcurrentEffect: ContextShift]: Fetch[F, Author] =
       Authors.fetchAuthor(1)
 
     val task = Fetch.runLog[Task](fetch)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.3")
+addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.11.3")
+addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.26")


### PR DESCRIPTION
This PR upgrades to sop `0.11.3`, switching to the Scala CoC, so the bot is not reverting the recent changes made.