### PR TITLE
refactor(fetch): Loosen effect constraint for liftIO.

### DIFF
--- a/shared/src/main/scala/fetch.scala
+++ b/shared/src/main/scala/fetch.scala
@@ -310,13 +310,8 @@ object `package` {
         ))
       )
 
-    def liftIO[F[_] : ConcurrentEffect, A](io: IO[A]): Fetch[F, A] =
-      Unfetch[F, A](
-        ConcurrentEffect[F].liftIO(io).attempt.map {
-          case Left(err) => Throw[F, A](log => UnhandledException(err, log))
-          case Right(r) => Done[F, A](r)
-        }
-      )
+    def liftIO[F[_] : Concurrent: LiftIO, A](io: IO[A]): Fetch[F, A] =
+      liftF(LiftIO[F].liftIO(io))
 
     def liftF[F[_] : Concurrent, A](f: F[A]): Fetch[F, A] =
       Unfetch[F, A](


### PR DESCRIPTION
Closes #213 

`Fetch.liftIO` really only requires `LiftIO` in addition to the `Concurrent` implicit constraint. Therefore we can loosen the constraint on the method to require a `Concurrent` and a `LiftIO` instead of a full `ConcurrentEffect`. Also collapses the the `liftIO` internals into a proxy call to `liftF`.